### PR TITLE
Add mobile responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Forestry Trail Terminal</title>
     <link rel="stylesheet" href="styles.css" />
   </head>

--- a/styles.css
+++ b/styles.css
@@ -78,3 +78,27 @@ h2 {
 .info-label {
   font-weight: bold;
 }
+
+@media (max-width: 600px) {
+  body {
+    align-items: flex-start;
+    height: auto;
+  }
+
+  .game-container {
+    flex-direction: column;
+    width: 100%;
+    height: auto;
+  }
+
+  .left-panel,
+  .right-panel {
+    width: 100%;
+    height: auto;
+  }
+
+  .left-panel {
+    border-right: none;
+    border-bottom: 2px solid #444;
+  }
+}


### PR DESCRIPTION
## Summary
- add viewport meta tag for mobile scaling
- stack panels vertically on small screens with a responsive media query

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68869edbc1b0832180ad9157a6e3dcf6