### PR TITLE
Improve mobile interface layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, user-scalable=no"
+    />
     <title>Forestry Trail Terminal</title>
     <link rel="stylesheet" href="styles.css" />
   </head>

--- a/styles.css
+++ b/styles.css
@@ -7,6 +7,7 @@ body {
   align-items: center;
   height: 100vh;
   margin: 0;
+  overflow: hidden;
 }
 
 .game-container {
@@ -38,16 +39,21 @@ body {
   overflow-y: auto;
   white-space: pre-wrap;
   flex-grow: 1;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
 }
 
 #input {
   width: 100%;
   font-family: monospace;
+  font-size: 16px;
   padding: 0.5em;
   box-sizing: border-box;
   background-color: #333;
   color: #0f0;
   border: 1px solid #444;
+  position: sticky;
+  bottom: 0;
 }
 
 .screen.swipe {
@@ -77,4 +83,33 @@ h2 {
 
 .info-label {
   font-weight: bold;
+}
+
+@media (max-width: 600px) {
+  body {
+    align-items: flex-start;
+    height: 100vh;
+    overflow: hidden;
+  }
+
+  .game-container {
+    flex-direction: column;
+    width: 100%;
+    height: 100vh;
+    overflow: hidden;
+  }
+
+  .left-panel,
+  .right-panel {
+    width: 100%;
+    height: auto;
+  }
+
+  .left-panel {
+    border-right: none;
+    border-bottom: 2px solid #444;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+  }
 }


### PR DESCRIPTION
## Summary
- disable page zooming via viewport meta tag
- keep page fixed and scroll only the terminal
- sticky input at bottom and overscroll containment for smoother chat scrolling on phones

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68869edbc1b0832180ad9157a6e3dcf6