### PR TITLE
Add story arc and community support mechanics to forestry sim

### DIFF
--- a/js/firstNationsAnger.js
+++ b/js/firstNationsAnger.js
@@ -246,11 +246,14 @@ export function check_anger_event_triggers(state) {
   
   // Check for recent violations or issues
   const hasRecentViolations = state.safety_violations > 2 || state.criminal_convictions > 0;
-  
+
   // Check if harvesting without proper consultation
-  const lackOfConsultation = state.harvest_blocks.some(block => 
+  const lackOfConsultation = state.harvest_blocks.some(block =>
     block.permit_status === "approved" && !block.fn_consulted
   );
-  
-  return hasAngryNation || hasRecentViolations || lackOfConsultation;
+
+  // Low community support can also trigger anger events
+  const lowCommunitySupport = state.community_support < 0.3;
+
+  return hasAngryNation || hasRecentViolations || lackOfConsultation || lowCommunitySupport;
 }

--- a/js/game.js
+++ b/js/game.js
@@ -11,6 +11,7 @@ import { ceo_management, pay_ceo_annual_costs, ceo_automated_decisions, ceo_quar
 import { random_first_nations_anger_events, check_anger_event_triggers } from "./firstNationsAnger.js";
 import { workplace_safety_incidents, ongoing_safety_consequences } from "./workplaceSafety.js";
 import { ask, formatCurrency, formatVolume } from "./utils.js";
+import { story_progression } from "./storyEvents.js";
 
 class Game {
   constructor() {
@@ -91,6 +92,7 @@ class Game {
       this.write("🌱 SPRING: Planning and permit season begins!");
       await this.eventsRouter.random_policy_events(this.state, this.write.bind(this), this.terminal, this.input);
       await ongoing_first_nations_consultation(this.state, this.write.bind(this), this.terminal, this.input);
+      await story_progression(this.state, this.write.bind(this), this.terminal, this.input);
       await plan_harvest_schedule(this.state, this.write.bind(this), this.terminal, this.input);
     } else if (this.state.quarter === 2) {
       this.write("☀️ SUMMER: Prime harvesting season!");
@@ -129,7 +131,8 @@ class Game {
     await workplace_safety_incidents(this.state, this.write.bind(this), this.terminal, this.input);
     
     // First Nations anger events
-    if (check_anger_event_triggers(this.state) || Math.random() < 0.25) {
+    const angerChance = Math.max(0.05, 0.25 - this.state.community_support * 0.15);
+    if (check_anger_event_triggers(this.state) || Math.random() < angerChance) {
       await random_first_nations_anger_events(this.state, this.write.bind(this), this.terminal, this.input);
     }
     
@@ -171,6 +174,7 @@ class Game {
     const quarter_names = ["", "Spring", "Summer", "Fall", "Winter"];
     const budgetColor = this.state.budget < 0 ? "style='color: #ff0000'" : "";
     const repColor = this.state.reputation < 0.3 ? "style='color: #ff9900'" : "";
+    const communityColor = this.state.community_support < 0.3 ? "style='color: #ff9900'" : "";
     
     this.statusPanel.innerHTML = `
       <div class="info-item">
@@ -184,6 +188,9 @@ class Game {
       </div>
       <div class="info-item">
         <span class="info-label">REPUTATION:</span> <span class="info-value" ${repColor}>${(this.state.reputation * 100).toFixed(0)}%</span>
+      </div>
+      <div class="info-item">
+        <span class="info-label">COMMUNITY SUPPORT:</span> <span class="info-value" ${communityColor}>${(this.state.community_support * 100).toFixed(0)}%</span>
       </div>
       <div class="info-item">
         <span class="info-label">AAC:</span> <span class="info-value">${formatVolume(this.state.annual_allowable_cut)}</span>

--- a/js/gameModels.js
+++ b/js/gameModels.js
@@ -152,6 +152,11 @@ export class GameState {
     this.consecutive_profitable_years = 0;
     this.social_license_maintained = true;
 
+    // Community & story progression
+    this.community_support = 0.5; // 0-1 scale
+    this.story_stage = 0;
+    this.story_branch = null;
+
     // First Nations liaison and CEO
     this.fn_liaison = null;
     this.ceo = null;

--- a/js/storyEvents.js
+++ b/js/storyEvents.js
@@ -1,0 +1,128 @@
+import { askChoice } from "./utils.js";
+
+/**
+ * Handles progression of the narrative story arc.
+ * @param {import("./gameModels.js").GameState} state
+ * @param {(text: string) => void} write
+ * @param {HTMLElement} terminal
+ * @param {HTMLInputElement} input
+ */
+export async function story_progression(state, write, terminal, input) {
+  switch (state.story_stage) {
+    case 0:
+      write("--- STORY EVENT: Discovery of the Ancient Grove ---");
+      write(
+        "Survey crews have found an untouched ancient cedar grove with trees older than 800 years. The community is eager to see what you do next."
+      );
+      {
+        const choice = await askChoice(
+          "How do you respond?",
+          [
+            "Protect the grove and seek heritage status",
+            "Harvest the valuable timber",
+          ],
+          terminal,
+          input
+        );
+        if (choice === 0) {
+          state.story_branch = "protect";
+          state.reputation += 0.05;
+          state.community_support += 0.2;
+          write(
+            "You announce the grove will be protected. Locals praise your stewardship."
+          );
+        } else {
+          state.story_branch = "harvest";
+          state.budget += 50000;
+          state.reputation -= 0.1;
+          state.community_support -= 0.2;
+          write(
+            "You move to harvest the grove. Profits rise, but protests begin to stir."
+          );
+        }
+        state.story_stage = 1;
+      }
+      break;
+    case 1:
+      if (state.story_branch === "protect") {
+        write("--- STORY EVENT: Eco-tourism Opportunity ---");
+        write(
+          "A local entrepreneur wants to create an eco-tourism venture around the protected grove."
+        );
+        const choice = await askChoice(
+          "Do you fund the project?",
+          ["Invest $40,000", "Decline"],
+          terminal,
+          input
+        );
+        if (choice === 0) {
+          if (state.budget >= 40000) {
+            state.budget -= 40000;
+            state.reputation += 0.1;
+            state.community_support += 0.1;
+            write(
+              "The eco-tourism project thrives, bringing goodwill and visitors."
+            );
+          } else {
+            write("You can't afford the investment right now.");
+          }
+        } else {
+          state.community_support -= 0.05;
+          write("The opportunity passes, disappointing some community members.");
+        }
+      } else if (state.story_branch === "harvest") {
+        write("--- STORY EVENT: Environmental Protest ---");
+        write(
+          "Activists blockade the road to the grove, demanding its preservation."
+        );
+        const choice = await askChoice(
+          "How do you respond?",
+          [
+            "Negotiate and offer partial protection",
+            "Call law enforcement to clear the blockade",
+          ],
+          terminal,
+          input
+        );
+        if (choice === 0) {
+          state.reputation += 0.05;
+          state.community_support += 0.1;
+          write("You reach a compromise, easing tensions.");
+        } else {
+          state.reputation -= 0.15;
+          state.community_support -= 0.15;
+          state.budget -= 20000;
+          write(
+            "The confrontation leads to negative press and legal expenses."
+          );
+        }
+      }
+      state.story_stage = 2;
+      break;
+    case 2:
+      write("--- STORY EVENT: Provincial Review ---");
+      if (state.story_branch === "protect") {
+        write(
+          "The province recognizes your stewardship and awards a sustainability grant."
+        );
+        state.budget += 60000;
+        state.reputation += 0.05;
+      } else {
+        write(
+          "The province fines your company for inadequate consultation during the harvest."
+        );
+        state.budget -= 40000;
+        state.reputation -= 0.05;
+      }
+      state.story_stage = 3;
+      break;
+    default:
+      // story concluded
+      break;
+  }
+
+  // Clamp values
+  state.reputation = Math.min(1, Math.max(0, state.reputation));
+  state.community_support = Math.min(1, Math.max(0, state.community_support));
+}
+


### PR DESCRIPTION
## Summary
- track community support and story progression in GameState
- add multi-stage narrative events influencing budget, reputation, and support
- integrate story and community metrics into gameplay and UI

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --input-type=module <<'NODE'\nimport { GameState } from './js/gameModels.js';\nimport { check_anger_event_triggers } from './js/firstNationsAnger.js';\n\nconst state = new GameState();\nconsole.log('initial community support', state.community_support);\nconsole.log('trigger?', check_anger_event_triggers(state));\nstate.community_support = 0.2;\nconsole.log('low support trigger?', check_anger_event_triggers(state));\nNODE`


------
https://chatgpt.com/codex/tasks/task_e_68940377a8848321810a16dd87e4afd1