### PR TITLE
Add random story arcs and operational upkeep

### DIFF
--- a/js/gameLogic.js
+++ b/js/gameLogic.js
@@ -493,6 +493,9 @@ export async function annual_management_decisions(state, write, terminal, input)
  */
 export async function quarter_end_summary(state, write) {
   write("\n--- QUARTER SUMMARY ---");
+  const upkeep = 100000;
+  state.budget -= upkeep;
+  write(`Operational upkeep: ${formatCurrency(upkeep)}`);
   write(`Budget: ${formatCurrency(state.budget)}`);
   write(`Reputation: ${state.reputation.toFixed(2)}`);
   write(`Safety record: ${state.safety_violations} violations`);

--- a/js/gameModels.js
+++ b/js/gameModels.js
@@ -156,6 +156,7 @@ export class GameState {
     this.community_support = 0.5; // 0-1 scale
     this.story_stage = 0;
     this.story_branch = null;
+    this.story_arc = null;
 
     // First Nations liaison and CEO
     this.fn_liaison = null;

--- a/js/storyEvents.js
+++ b/js/storyEvents.js
@@ -2,12 +2,37 @@ import { askChoice } from "./utils.js";
 
 /**
  * Handles progression of the narrative story arc.
+ * Randomly selects a story arc on first run and advances it annually.
  * @param {import("./gameModels.js").GameState} state
  * @param {(text: string) => void} write
  * @param {HTMLElement} terminal
  * @param {HTMLInputElement} input
  */
 export async function story_progression(state, write, terminal, input) {
+  if (!state.story_arc) {
+    const arcs = ["ancientGrove", "rivalCompany", "endangeredSpecies"];
+    state.story_arc = arcs[Math.floor(Math.random() * arcs.length)];
+    state.story_stage = 0;
+  }
+
+  switch (state.story_arc) {
+    case "ancientGrove":
+      await ancientGroveStory(state, write, terminal, input);
+      break;
+    case "rivalCompany":
+      await rivalCompanyStory(state, write, terminal, input);
+      break;
+    case "endangeredSpecies":
+      await endangeredSpeciesStory(state, write, terminal, input);
+      break;
+  }
+
+  // Clamp values
+  state.reputation = Math.min(1, Math.max(0, state.reputation));
+  state.community_support = Math.min(1, Math.max(0, state.community_support));
+}
+
+async function ancientGroveStory(state, write, terminal, input) {
   switch (state.story_stage) {
     case 0:
       write("--- STORY EVENT: Discovery of the Ancient Grove ---");
@@ -117,12 +142,198 @@ export async function story_progression(state, write, terminal, input) {
       state.story_stage = 3;
       break;
     default:
-      // story concluded
       break;
   }
-
-  // Clamp values
-  state.reputation = Math.min(1, Math.max(0, state.reputation));
-  state.community_support = Math.min(1, Math.max(0, state.community_support));
 }
 
+async function rivalCompanyStory(state, write, terminal, input) {
+  switch (state.story_stage) {
+    case 0:
+      write("--- STORY EVENT: Rival Company Encroachment ---");
+      write(
+        "A rival logging firm has begun working near your tenure and wants to buy some of your cutting rights."
+      );
+      {
+        const choice = await askChoice(
+          "How do you respond?",
+          ["Negotiate partnership", "Compete aggressively"],
+          terminal,
+          input
+        );
+        if (choice === 0) {
+          state.story_branch = "partner";
+          state.reputation += 0.05;
+          state.community_support += 0.1;
+          write("You open talks for a potential joint venture.");
+        } else {
+          state.story_branch = "compete";
+          state.budget -= 20000;
+          state.reputation -= 0.05;
+          write("You vow to defend your territory and ramp up operations.");
+        }
+        state.story_stage = 1;
+      }
+      break;
+    case 1:
+      if (state.story_branch === "partner") {
+        write("--- STORY EVENT: Joint Infrastructure Decision ---");
+        write("The partner proposes a $50,000 investment in shared roads.");
+        const choice = await askChoice(
+          "Do you contribute?",
+          ["Invest", "Decline"],
+          terminal,
+          input
+        );
+        if (choice === 0) {
+          if (state.budget >= 50000) {
+            state.budget -= 50000;
+            state.reputation += 0.1;
+            write("The project improves access for both companies.");
+          } else {
+            write("You can't afford to invest right now.");
+          }
+        } else {
+          state.reputation -= 0.05;
+          write("The partnership wavers due to lack of commitment.");
+        }
+      } else {
+        write("--- STORY EVENT: Marketing Battle ---");
+        write(
+          "The rival launches a PR campaign criticizing your practices."
+        );
+        const choice = await askChoice(
+          "Your move?",
+          ["Counter with $30k campaign", "Ignore them"],
+          terminal,
+          input
+        );
+        if (choice === 0) {
+          if (state.budget >= 30000) {
+            state.budget -= 30000;
+            state.reputation += 0.05;
+            write("Your campaign restores some public trust.");
+          } else {
+            write("Insufficient funds to counter the campaign.");
+          }
+        } else {
+          state.reputation -= 0.1;
+          state.community_support -= 0.05;
+          write("The rival's narrative gains traction.");
+        }
+      }
+      state.story_stage = 2;
+      break;
+    case 2:
+      if (state.story_branch === "partner") {
+        write("--- STORY EVENT: Joint Venture Payoff ---");
+        write("Regulators approve the partnership, unlocking new markets.");
+        state.budget += 70000;
+        state.reputation += 0.05;
+      } else {
+        write("--- STORY EVENT: Costly Competition ---");
+        write("The price war drives up your costs and exhausts crews.");
+        state.budget -= 40000;
+        state.reputation += 0.02;
+      }
+      state.story_stage = 3;
+      break;
+    default:
+      break;
+  }
+}
+
+async function endangeredSpeciesStory(state, write, terminal, input) {
+  switch (state.story_stage) {
+    case 0:
+      write("--- STORY EVENT: Endangered Species Habitat ---");
+      write(
+        "Biologists discover habitat of an endangered species in a planned cut block."
+      );
+      {
+        const choice = await askChoice(
+          "What do you do?",
+          ["Set aside habitat (-$20k)", "Apply for exemption"],
+          terminal,
+          input
+        );
+        if (choice === 0) {
+          state.story_branch = "protect";
+          state.budget -= 20000;
+          state.reputation += 0.1;
+          state.community_support += 0.1;
+          write("You reserve the area, earning praise from conservationists.");
+        } else {
+          state.story_branch = "exempt";
+          state.budget += 50000;
+          state.reputation -= 0.1;
+          state.community_support -= 0.1;
+          write("You seek an exemption to continue logging.");
+        }
+        state.story_stage = 1;
+      }
+      break;
+    case 1:
+      if (state.story_branch === "protect") {
+        write("--- STORY EVENT: NGO Partnership ---");
+        write("An environmental NGO proposes an education campaign.");
+        const choice = await askChoice(
+          "Fund $10k outreach effort?",
+          ["Fund campaign", "Decline"],
+          terminal,
+          input
+        );
+        if (choice === 0) {
+          if (state.budget >= 10000) {
+            state.budget -= 10000;
+            state.reputation += 0.1;
+            write("The campaign boosts your green image.");
+          } else {
+            write("You lack funds for the campaign.");
+          }
+        } else {
+          state.reputation -= 0.05;
+          write("The NGO criticizes your lack of support.");
+        }
+      } else {
+        write("--- STORY EVENT: Legal Threat ---");
+        write("Environmental groups threaten a lawsuit over the exemption.");
+        const choice = await askChoice(
+          "How do you respond?",
+          ["Settle ($40k)", "Fight in court"],
+          terminal,
+          input
+        );
+        if (choice === 0) {
+          if (state.budget >= 40000) {
+            state.budget -= 40000;
+            state.reputation -= 0.05;
+            write("You settle quietly, but the story leaks.");
+          } else {
+            write("You can't afford to settle.");
+          }
+        } else {
+          state.budget -= 20000;
+          state.reputation -= 0.1;
+          write("The legal battle drags on, draining resources.");
+        }
+      }
+      state.story_stage = 2;
+      break;
+    case 2:
+      if (state.story_branch === "protect") {
+        write("--- STORY EVENT: Conservation Grant ---");
+        write("The province awards a grant for your stewardship.");
+        state.budget += 40000;
+        state.reputation += 0.05;
+      } else {
+        write("--- STORY EVENT: Court Ruling ---");
+        write("The court restricts your operations and imposes penalties.");
+        state.budget -= 30000;
+        state.reputation -= 0.05;
+      }
+      state.story_stage = 3;
+      break;
+    default:
+      break;
+  }
+}


### PR DESCRIPTION
## Summary
- Introduce multiple narrative arcs that are chosen at random when the game begins, adding scenarios like rival logging companies and endangered species discoveries.
- Track selected story arc in game state and update story progression accordingly.
- Deduct a fixed quarterly operating upkeep to make finances more challenging.

## Testing
- `node --check js/storyEvents.js`
- `node --check js/gameLogic.js`
- `node --check js/gameModels.js`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689413b181cc83218afdf3774f1b0411