### PR TITLE
Improve mobile choice UI and add collapsible status panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,9 +30,16 @@
         />
       </div>
       <div class="right-panel" id="status-panel">
-        <div class="status-header">
+        <div
+          id="status-toggle"
+          class="status-header"
+          role="button"
+          aria-expanded="true"
+          aria-controls="status-content"
+          tabindex="0"
+        >
           <h2>System Status</h2>
-          <button id="status-collapse" class="icon-btn small" aria-expanded="true" aria-controls="status-content">▾</button>
+          <span class="status-arrow" aria-hidden="true">▾</span>
         </div>
         <div id="status-content" class="status-content"></div>
       </div>

--- a/js/game.js
+++ b/js/game.js
@@ -22,10 +22,12 @@ class Game {
     this.terminal = document.getElementById("terminal");
     this.input = document.getElementById("input");
     this.statusPanel = document.getElementById("status-content");
+    this.statusToggle = document.getElementById("status-toggle");
     this.enable_wacky_events = false;
     this.eventsRouter = new EventsRouter();
     this.mobileHud = document.getElementById("mobile-hud");
     this._bindSettingsUI();
+    this._bindStatusToggle();
   }
 
   async start() {
@@ -295,6 +297,32 @@ class Game {
     sizeSmall?.addEventListener('click', () => setSize('small'));
     sizeMedium?.addEventListener('click', () => setSize('medium'));
     sizeLarge?.addEventListener('click', () => setSize('large'));
+  }
+
+  _bindStatusToggle() {
+    const toggle = this.statusToggle;
+    const content = this.statusPanel;
+    if (!toggle || !content) return;
+    const arrow = toggle.querySelector('.status-arrow');
+
+    const collapse = () => {
+      const expanded = toggle.getAttribute('aria-expanded') === 'true';
+      toggle.setAttribute('aria-expanded', (!expanded).toString());
+      content.style.display = expanded ? 'none' : 'block';
+      if (arrow) arrow.textContent = expanded ? '▸' : '▾';
+    };
+
+    toggle.addEventListener('click', collapse);
+    toggle.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        collapse();
+      }
+    });
+
+    if (window.innerWidth <= 768) {
+      collapse();
+    }
   }
 }
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -82,6 +82,11 @@ export function askChoiceWithButtons(question, options, terminal, input) {
     input.style.display = 'none';
     buttonContainer.style.display = 'flex';
     buttonContainer.innerHTML = '';
+
+    const questionHeader = document.createElement('div');
+    questionHeader.className = 'button-question';
+    questionHeader.textContent = question;
+    buttonContainer.appendChild(questionHeader);
     
     const handleChoice = (index) => {
       // Show the user's choice in terminal

--- a/styles.css
+++ b/styles.css
@@ -80,6 +80,19 @@ body[data-text-size="large"] .terminal { font-size: 18px; }
   font-size: 14px;
 }
 
+.status-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+}
+
+.status-arrow {
+  font-size: 18px;
+  line-height: 1;
+  margin-left: 8px;
+}
+
 .terminal {
   background: #000;
   color: #00ff00;
@@ -259,6 +272,12 @@ h2 {
   scrollbar-color: #00ff00 #000;
 }
 
+.button-question {
+  font-weight: bold;
+  margin-bottom: 8px;
+  color: #00ff00;
+}
+
 .button-container::-webkit-scrollbar {
   width: 6px;
 }
@@ -351,14 +370,24 @@ h2 {
 /* Mobile adjustments for buttons */
 @media (max-width: 768px) {
   .button-container {
-    padding: 8px 15px;
-    gap: 6px;
-    max-height: 150px;
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    padding: 12px 20px;
+    gap: 8px;
+    max-height: 50vh;
+    z-index: 1000;
   }
-  
+
+  .button-question {
+    font-size: 16px;
+    margin-bottom: 10px;
+  }
+
   .choice-button {
-    padding: 10px 12px;
-    font-size: 13px;
+    padding: 14px 16px;
+    font-size: 16px;
     border-radius: 6px;
   }
 }


### PR DESCRIPTION
## Summary
- Make system status panel collapsible with a toggle header
- Present question text above mobile choice buttons and enlarge options
- Style mobile button container as bottom overlay for better visibility

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_6894f5057de0832192ede8cfda150cf2