### PR TITLE
Move glossary assist into modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,127 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
+    <div id="init-overlay" class="init-overlay" hidden>
+      <div class="init-frame">
+        <div class="init-topline">
+          <div class="init-brand">BC_FORESTRY_SIM // v1.4</div>
+          <div class="init-coordinates">LAT: 53.7°N | LON: -122.7°W | STATUS: ONLINE</div>
+        </div>
+
+        <div class="init-progress" id="init-progress">
+          <div class="progress-dot active" data-step="intro">
+            <span class="dot-index">01</span>
+            <span class="dot-label">Crew Handle</span>
+          </div>
+          <div class="progress-dot" data-step="role">
+            <span class="dot-index">02</span>
+            <span class="dot-label">Role Selection</span>
+          </div>
+          <div class="progress-dot" data-step="area">
+            <span class="dot-index">03</span>
+            <span class="dot-label">Operating Area</span>
+          </div>
+        </div>
+
+        <section id="intro-step" class="init-step">
+          <div class="init-grid intro-grid">
+            <div class="intro-panel">
+              <p class="eyebrow">TERMINAL // ID-88X</p>
+              <h2 class="init-title">SYSTEM READY</h2>
+              <p class="lede">
+                Welcome, Operator. You have been assigned to the BC Forestry Operations System.
+                Confirm your crew and initialize the simulation to proceed.
+              </p>
+              <ul class="system-checks">
+                <li><span class="check">•</span> Loading BEC Zones........................................ OK</li>
+                <li><span class="check">•</span> Calibrating harvesting links............................ UPDATED</li>
+                <li><span class="check">•</span> Checking market rates................................... OK</li>
+                <li><span class="check">•</span> Establishing connection to HQ........................... CONNECTED</li>
+              </ul>
+
+              <label class="field-label" for="crew-name-input">Crew Handle</label>
+              <div class="field-row">
+                <input id="crew-name-input" class="init-input" type="text" value="The Timber Wolves" />
+                <button id="intro-continue-btn" class="init-primary" type="button">[> Initialize Role]</button>
+              </div>
+            </div>
+
+            <div class="intro-visual">
+              <div class="visual-header">
+                <span class="pill">NORTHERN CANOPY SIM</span>
+                <span class="pill">BUILD 1.4.0</span>
+              </div>
+              <div class="visual-body">
+                <div class="visual-signal">SIGNAL: STABLE</div>
+                <div class="visual-caption">SUSTAINABILITY THROUGH DATA</div>
+                <div class="visual-grid">
+                  <div>
+                    <p class="muted">CURRENT FOCUS</p>
+                    <p class="value">Resource Integrity</p>
+                  </div>
+                  <div>
+                    <p class="muted">SIM TYPE</p>
+                    <p class="value">Field / Desk Hybrid</p>
+                  </div>
+                  <div>
+                    <p class="muted">NETWORK</p>
+                    <p class="value">BC_FORESTRY_NET</p>
+                  </div>
+                  <div>
+                    <p class="muted">DATE</p>
+                    <p class="value">Q3 // FY24</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section id="role-step" class="init-step" hidden>
+          <header class="step-header">
+            <div>
+              <p class="eyebrow">SYSTEM INITIALIZATION // USER_ALLOCATION</p>
+              <h2 class="init-title">Select your operational specialization</h2>
+            </div>
+            <div class="step-meta">
+              <span class="pill">OPERATOR CLASS</span>
+              <span class="pill">CREW SIZE: 5</span>
+            </div>
+          </header>
+
+          <div id="role-grid" class="card-grid"></div>
+
+          <footer class="step-footer">
+            <button id="role-glossary-btn" class="init-ghost" type="button">[?] Glossary Assist</button>
+            <button id="role-continue-btn" class="init-primary" type="button">[> Confirm Role]</button>
+          </footer>
+        </section>
+
+        <section id="area-step" class="init-step" hidden>
+          <header class="step-header">
+            <div>
+              <p class="eyebrow">SYSTEM ALERT: SELECT OPERATING THEATRE</p>
+              <h2 class="init-title">Connect to an operating area to deploy</h2>
+            </div>
+            <div class="step-meta">
+              <span class="pill">DATA LINK // SECURE</span>
+              <span class="pill">GLOSSARY READY</span>
+            </div>
+          </header>
+
+          <div class="area-grid">
+            <div id="area-list" class="area-list" role="list"></div>
+            <div class="area-detail" id="area-detail"></div>
+          </div>
+
+          <footer class="step-footer">
+            <button id="area-glossary-btn" class="init-ghost" type="button">[?] Glossary Assist</button>
+            <button id="area-continue-btn" class="init-primary" type="button">[> Initialize Deployment]</button>
+          </footer>
+        </section>
+      </div>
+    </div>
+
     <div class="game-wrapper">
       <!-- Main game screen -->
       <main class="game-screen">

--- a/js/game.js
+++ b/js/game.js
@@ -81,42 +81,25 @@ class ForestryTrailGame {
     this.gameOver = false;
     this.victory = false;
 
-    // Title screen
-    this.ui.writeHeader('BC FORESTRY TRAIL');
+    const init = await this.ui.runInitializationFlow({
+      defaultCrewName: 'The Timber Wolves',
+      roles: FORESTER_ROLES,
+      areas: OPERATING_AREAS
+    });
+
+    const crewName = init?.crewName || 'The Timber Wolves';
+    const role = init?.role || FORESTER_ROLES[0];
+    const area = init?.area || OPERATING_AREAS[0];
+
+    this.ui.clear();
+    this.ui.writeHeader('BC FORESTRY OPERATIONS SYSTEM');
+    this.ui.write('System online. Deployment package confirmed.');
     this.ui.write('');
-    this.ui.write('The year is 2024. You have been assigned to lead');
-    this.ui.write('a forestry operation in northern British Columbia.');
+    this.ui.write(`Crew Handle: ${crewName}`);
+    this.ui.write(`Role: ${role.name}`);
+    this.ui.write(`Operating Area: ${area.name}`);
+    this.ui.write(`BEC Zone: ${area.becZone}`);
     this.ui.write('');
-    this.ui.write('Your decisions will determine whether your crew');
-    this.ui.write('completes their mission... or faces disaster.');
-    this.ui.write('');
-
-    // Character creation
-    const crewName = await this.ui.promptText('Name your crew:', 'The Timber Wolves');
-
-    // Role selection
-    this.ui.writeDivider('SELECT YOUR ROLE');
-    const roleOptions = FORESTER_ROLES.map(role => ({
-      label: role.name,
-      description: role.description,
-      value: role.id
-    }));
-
-    const roleChoice = await this.ui.promptChoice('What is your specialization?', roleOptions);
-    const roleId = roleChoice.value || roleChoice.label.toLowerCase().replace(/\s+/g, '_');
-    const role = FORESTER_ROLES.find(r => r.id === roleId) || FORESTER_ROLES[0];
-
-    // Area selection
-    this.ui.writeDivider('SELECT OPERATING AREA');
-    const areaOptions = OPERATING_AREAS.map(area => ({
-      label: area.name,
-      description: area.description,
-      value: area.id
-    }));
-
-    const areaChoice = await this.ui.promptChoice('Where will you operate?', areaOptions);
-    const areaId = areaChoice.value || areaChoice.label.toLowerCase().replace(/\s+/g, '_');
-    const area = OPERATING_AREAS.find(a => a.id === areaId) || OPERATING_AREAS[0];
 
     // Create journey based on role type
     const journeyType = role.journeyType || 'field';

--- a/styles.css
+++ b/styles.css
@@ -14,6 +14,13 @@
   --border-color: #1a5c1a;
   --border-bright: #33ff33;
   --glow: rgba(51, 255, 51, 0.3);
+  --bg-overlay: #040b04;
+  --card: rgba(16, 32, 16, 0.85);
+  --card-strong: rgba(20, 48, 20, 0.95);
+  --fg-muted: #66b566;
+  --fg-label: #77ff77;
+  --accent: #00ff99;
+  --accent-2: #00d87a;
 
   /* Typography */
   --font-mono: 'Courier New', Courier, 'Lucida Console', monospace;
@@ -55,6 +62,506 @@ body {
   font-size: var(--font-size-base);
   line-height: 1.5;
   overflow-x: hidden;
+}
+
+/* Intro overlay */
+.init-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: var(--space-lg);
+  background: radial-gradient(circle at 20% 20%, rgba(0, 255, 153, 0.08), transparent 30%),
+    radial-gradient(circle at 80% 30%, rgba(0, 255, 51, 0.06), transparent 25%),
+    var(--bg-overlay);
+  backdrop-filter: blur(2px);
+  z-index: 20;
+}
+
+.init-frame {
+  width: min(1200px, 100%);
+  background: linear-gradient(145deg, rgba(5, 15, 5, 0.9), rgba(8, 20, 8, 0.94));
+  border: 1px solid var(--border-color);
+  box-shadow: 0 0 20px rgba(0, 255, 51, 0.15), inset 0 0 0 1px rgba(0, 255, 51, 0.15);
+  padding: var(--space-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+  min-height: 85vh;
+  max-height: 90vh;
+  overflow: hidden;
+}
+
+.init-topline {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: var(--font-size-sm);
+  color: var(--fg-muted);
+  letter-spacing: 0.5px;
+}
+
+.init-brand {
+  color: var(--fg-bright);
+  font-weight: bold;
+  text-shadow: 0 0 12px var(--glow);
+}
+
+.init-coordinates {
+  color: var(--fg-muted);
+}
+
+.init-progress {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-sm);
+  padding: var(--space-sm);
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid var(--border-color);
+  box-shadow: inset 0 0 0 1px rgba(0, 255, 51, 0.08);
+}
+
+.progress-dot {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  color: var(--fg-muted);
+  border: 1px solid transparent;
+  background: linear-gradient(90deg, rgba(0, 20, 10, 0.6), rgba(0, 20, 10, 0.3));
+  transition: border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
+}
+
+.progress-dot.active {
+  border-color: var(--accent);
+  color: var(--fg-main);
+  box-shadow: 0 0 10px rgba(0, 255, 51, 0.18);
+}
+
+.progress-dot.complete {
+  color: var(--fg-bright);
+  border-color: rgba(0, 255, 51, 0.4);
+}
+
+.dot-index {
+  font-weight: 700;
+  font-size: var(--font-size-sm);
+  letter-spacing: 1px;
+}
+
+.dot-label {
+  font-size: var(--font-size-sm);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.init-step {
+  display: none;
+  flex-direction: column;
+  gap: var(--space-md);
+  min-height: 0;
+}
+
+.init-step.active {
+  display: flex;
+  animation: pageSlide 0.45s ease;
+}
+
+.init-grid {
+  display: grid;
+  gap: var(--space-md);
+}
+
+.intro-grid {
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  align-items: stretch;
+}
+
+.intro-panel,
+.intro-visual,
+.card-grid,
+.area-list,
+.area-detail {
+  border: 1px solid var(--border-color);
+  background: var(--card);
+  box-shadow: inset 0 0 0 1px rgba(0, 255, 51, 0.08);
+}
+
+.intro-panel {
+  padding: var(--space-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.eyebrow {
+  color: var(--fg-muted);
+  letter-spacing: 1.5px;
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+}
+
+.init-title {
+  font-size: 28px;
+  letter-spacing: 1px;
+  color: var(--fg-bright);
+  text-shadow: 0 0 18px var(--glow);
+}
+
+.lede {
+  color: var(--fg-muted);
+  line-height: 1.7;
+}
+
+.system-checks {
+  list-style: none;
+  font-family: var(--font-mono);
+  color: var(--fg-main);
+  line-height: 1.8;
+}
+
+.system-checks .check {
+  color: var(--accent);
+  margin-right: var(--space-sm);
+}
+
+.field-label {
+  display: block;
+  color: var(--fg-label);
+  font-size: var(--font-size-sm);
+  margin-bottom: var(--space-xs);
+  letter-spacing: 1px;
+}
+
+.field-row {
+  display: flex;
+  gap: var(--space-sm);
+  align-items: center;
+}
+
+.init-input {
+  flex: 1;
+  background: var(--bg-input);
+  color: var(--fg-main);
+  border: 1px solid var(--border-color);
+  padding: var(--space-sm) var(--space-md);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-base);
+}
+
+.init-primary {
+  background: linear-gradient(90deg, var(--accent), var(--accent-2));
+  color: #001a0a;
+  border: 1px solid var(--border-bright);
+  padding: var(--space-sm) var(--space-md);
+  font-family: var(--font-mono);
+  letter-spacing: 1px;
+  cursor: pointer;
+  text-transform: uppercase;
+  font-weight: 700;
+  box-shadow: 0 0 12px rgba(0, 255, 153, 0.35);
+}
+
+.init-primary:hover,
+.init-primary:focus {
+  filter: brightness(1.1);
+  outline: none;
+}
+
+.init-ghost {
+  background: transparent;
+  color: var(--fg-main);
+  border: 1px dashed var(--border-color);
+  padding: var(--space-sm) var(--space-md);
+  font-family: var(--font-mono);
+  letter-spacing: 1px;
+  cursor: pointer;
+  text-transform: uppercase;
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.init-ghost:hover,
+.init-ghost:focus {
+  border-color: var(--border-bright);
+  color: var(--fg-bright);
+  outline: none;
+}
+
+.init-ghost:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.intro-visual {
+  padding: var(--space-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  background: radial-gradient(circle at 60% 30%, rgba(0, 255, 153, 0.08), transparent 45%), var(--card-strong);
+}
+
+.visual-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.pill {
+  display: inline-block;
+  padding: 6px 10px;
+  border: 1px solid var(--border-color);
+  background: rgba(0, 255, 51, 0.05);
+  color: var(--fg-label);
+  font-size: var(--font-size-xs);
+  letter-spacing: 0.5px;
+}
+
+.visual-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.visual-signal {
+  font-size: var(--font-size-lg);
+  color: var(--fg-bright);
+  letter-spacing: 2px;
+}
+
+.visual-caption {
+  color: var(--fg-muted);
+  letter-spacing: 1px;
+}
+
+.visual-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: var(--space-md);
+}
+
+.visual-grid .muted {
+  color: var(--fg-muted);
+  font-size: var(--font-size-sm);
+  letter-spacing: 0.5px;
+}
+
+.visual-grid .value {
+  color: var(--fg-main);
+  font-size: var(--font-size-lg);
+}
+
+.step-header,
+.step-footer {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-md);
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.step-meta {
+  display: flex;
+  gap: var(--space-sm);
+  align-items: center;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--space-md);
+  padding: var(--space-md);
+}
+
+.role-card {
+  border: 1px solid var(--border-color);
+  padding: var(--space-md);
+  background: rgba(0, 0, 0, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.role-card h3 {
+  color: var(--fg-bright);
+}
+
+.role-card .role-id {
+  color: var(--fg-muted);
+  font-size: var(--font-size-xs);
+  letter-spacing: 1px;
+}
+
+.role-card .role-desc {
+  color: var(--fg-main);
+  font-size: var(--font-size-sm);
+}
+
+.role-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  color: var(--fg-muted);
+  font-size: var(--font-size-xs);
+}
+
+.role-card.selected {
+  border-color: var(--border-bright);
+  box-shadow: 0 0 15px rgba(0, 255, 51, 0.25);
+}
+
+.role-card:hover {
+  border-color: var(--fg-bright);
+}
+
+.glossary-panel {
+  flex: 1;
+  min-width: 280px;
+  border: 1px solid var(--border-color);
+  padding: var(--space-md);
+  background: rgba(0, 0, 0, 0.3);
+}
+
+.glossary-panel h4 {
+  margin-bottom: var(--space-sm);
+  color: var(--fg-label);
+  letter-spacing: 1px;
+}
+
+.glossary-term {
+  margin-bottom: var(--space-sm);
+}
+
+.glossary-term-title {
+  color: var(--fg-bright);
+  font-size: var(--font-size-sm);
+}
+
+.glossary-term-desc {
+  color: var(--fg-muted);
+  font-size: var(--font-size-sm);
+}
+
+.modal-glossary-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  max-height: 55vh;
+  overflow: auto;
+}
+
+.modal-glossary-term {
+  border: 1px solid var(--border-color);
+  padding: var(--space-sm) var(--space-md);
+  background: rgba(0, 0, 0, 0.25);
+}
+
+.modal-glossary-title {
+  color: var(--fg-bright);
+  font-weight: 700;
+  letter-spacing: 0.5px;
+}
+
+.modal-glossary-desc {
+  color: var(--fg-muted);
+  margin-top: 4px;
+  line-height: 1.5;
+}
+
+.area-grid {
+  display: grid;
+  grid-template-columns: 360px 1fr;
+  gap: var(--space-md);
+}
+
+.area-list {
+  padding: var(--space-sm);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.area-item {
+  border: 1px solid var(--border-color);
+  padding: var(--space-sm);
+  text-align: left;
+  background: rgba(0, 0, 0, 0.15);
+  cursor: pointer;
+  display: grid;
+  grid-template-columns: 48px 1fr;
+  gap: var(--space-sm);
+  align-items: center;
+}
+
+.area-item strong {
+  color: var(--fg-bright);
+}
+
+.area-item .area-number {
+  text-align: center;
+  color: var(--fg-muted);
+  font-size: var(--font-size-sm);
+}
+
+.area-item.selected {
+  border-color: var(--border-bright);
+  background: rgba(0, 255, 51, 0.08);
+}
+
+.area-detail {
+  padding: var(--space-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.area-meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--space-md);
+}
+
+.detail-label {
+  color: var(--fg-muted);
+  font-size: var(--font-size-xs);
+  letter-spacing: 1px;
+}
+
+.detail-value {
+  color: var(--fg-main);
+  font-size: var(--font-size-lg);
+}
+
+.chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+}
+
+.chip {
+  border: 1px solid var(--border-color);
+  padding: 4px 8px;
+  color: var(--fg-label);
+  font-size: var(--font-size-xs);
+  background: rgba(0, 255, 51, 0.06);
+}
+
+.muted {
+  color: var(--fg-muted);
+}
+
+@media (max-width: 960px) {
+  .area-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .field-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
 }
 
 /* Game wrapper */
@@ -753,6 +1260,17 @@ body {
   .status-item {
     flex: 1;
     min-width: 60px;
+  }
+}
+
+@keyframes pageSlide {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
 }
 


### PR DESCRIPTION
## Summary
- replace the inline initialization glossary panels with dedicated modal triggers on the role and area steps
- add contextual glossary modal rendering with button states that disable when no terms are available
- style the new ghost buttons and modal glossary list entries to match the initialization overlay

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b3621c854833195ab7577d4295fcf)