### PR TITLE
Add round-level downside consequence mechanics

### DIFF
--- a/cli.mjs
+++ b/cli.mjs
@@ -5,6 +5,7 @@ import {
   createInitialState,
   getRoleTasks,
   applyEffects,
+  applyRoundConsequences,
   drawIssue,
   buildSummary,
   formatMetricDelta,
@@ -99,6 +100,7 @@ for (let run = 1; run <= runs; run++) {
         round,
       });
     }
+    applyRoundConsequences(state);
   }
 
   const summary = buildSummary(state);

--- a/js/engine.js
+++ b/js/engine.js
@@ -6,6 +6,9 @@ import {
 
 export const SEASONS = ["Spring Planning", "Summer Field", "Fall Integration", "Winter Review"];
 const ISSUE_REPEAT_COOLDOWN_ROUNDS = 2;
+const BUDGET_ATTRITION_THRESHOLD = 25;
+const RELATIONSHIP_TRUST_THRESHOLD = 35;
+const COMPLIANCE_AUDIT_THRESHOLD = 40;
 
 export function findRole(roleId) {
   return FORESTER_ROLES.find((role) => role.id === roleId);
@@ -65,7 +68,10 @@ export function applyEffects(state, effects = {}, source) {
   for (const key of Object.keys(metrics)) {
     if (delta[key] !== undefined) {
       const value = Number(delta[key]);
-      const adjustedDelta = Number.isFinite(value) ? applyDiminishingReturns(metrics[key], value) : 0;
+      let adjustedDelta = Number.isFinite(value) ? applyDiminishingReturns(metrics[key], value) : 0;
+      if (state.flags?.trustDeficitActive && key === "relationships" && adjustedDelta > 0) {
+        adjustedDelta = Math.max(1, Math.floor(adjustedDelta * 0.5));
+      }
       delta[key] = adjustedDelta;
       metrics[key] = clamp(metrics[key] + adjustedDelta, 0, 100);
     }
@@ -73,6 +79,83 @@ export function applyEffects(state, effects = {}, source) {
   if (source) {
     state.history.push({ ...source, effects: delta });
   }
+}
+
+export function applyRoundConsequences(state) {
+  if (!state?.metrics || !state?.flags) {
+    return [];
+  }
+
+  const consequences = [];
+  const { metrics, flags } = state;
+  const round = Number(state.round || 0);
+
+  if (metrics.budget < BUDGET_ATTRITION_THRESHOLD) {
+    flags.lowBudgetStreak = Number(flags.lowBudgetStreak || 0) + 1;
+  } else {
+    flags.lowBudgetStreak = 0;
+  }
+
+  if (metrics.compliance < COMPLIANCE_AUDIT_THRESHOLD) {
+    flags.lowComplianceStreak = Number(flags.lowComplianceStreak || 0) + 1;
+  } else {
+    flags.lowComplianceStreak = 0;
+  }
+
+  if (metrics.relationships < RELATIONSHIP_TRUST_THRESHOLD) {
+    flags.trustDeficitActive = true;
+  } else if (metrics.relationships >= RELATIONSHIP_TRUST_THRESHOLD + 10) {
+    flags.trustDeficitActive = false;
+  }
+
+  if (flags.lowBudgetStreak >= 2) {
+    applyEffects(
+      state,
+      { progress: -6, relationships: -4 },
+      {
+        type: "consequence",
+        id: "contractor-attrition",
+        title: "Contractor attrition from sustained budget stress",
+        option: "Deferred scopes and partner pullback",
+        round,
+      },
+    );
+    flags.contractorAttritionActive = true;
+    consequences.push("contractor-attrition");
+  }
+
+  if (flags.trustDeficitActive) {
+    applyEffects(
+      state,
+      { compliance: -3 },
+      {
+        type: "consequence",
+        id: "trust-deficit",
+        title: "Low-trust environment limited high-confidence pathways",
+        option: "Escalated approvals and slower collaboration",
+        round,
+      },
+    );
+    consequences.push("trust-deficit");
+  }
+
+  if (flags.lowComplianceStreak >= 2) {
+    applyEffects(
+      state,
+      { budget: -6, progress: -4 },
+      {
+        type: "consequence",
+        id: "audit-escalation",
+        title: "Audit escalation after repeated compliance drops",
+        option: "Emergency documentation and stoppage delays",
+        round,
+      },
+    );
+    flags.auditEscalationActive = true;
+    consequences.push("audit-escalation");
+  }
+
+  return consequences;
 }
 
 export function getRoleTasks(state) {

--- a/test_strategies.js
+++ b/test_strategies.js
@@ -8,6 +8,7 @@ import {
   createInitialState,
   getRoleTasks,
   applyEffects,
+  applyRoundConsequences,
   drawIssue,
   buildSummary,
 } from './js/engine.js';
@@ -77,6 +78,7 @@ for (const role of FORESTER_ROLES) {
           round,
         });
       }
+      applyRoundConsequences(state);
     }
 
     const summary = buildSummary(state);

--- a/tests/roundConsequences.test.mjs
+++ b/tests/roundConsequences.test.mjs
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createInitialState, applyRoundConsequences, applyEffects } from '../js/engine.js';
+
+function makeState() {
+  return createInitialState({
+    companyName: 'Test Outfit',
+    roleId: 'recce',
+    areaId: 'fort-st-john-plateau',
+  });
+}
+
+test('budget attrition triggers after two consecutive low-budget rounds', () => {
+  const state = makeState();
+
+  state.round = 1;
+  state.metrics.budget = 24;
+  let consequences = applyRoundConsequences(state);
+  assert.deepEqual(consequences, []);
+  assert.equal(state.metrics.progress, 50);
+
+  state.round = 2;
+  state.metrics.budget = 22;
+  consequences = applyRoundConsequences(state);
+  assert.ok(consequences.includes('contractor-attrition'));
+  assert.equal(state.metrics.progress, 44);
+  assert.equal(state.metrics.relationships, 46);
+});
+
+test('trust deficit applies compliance drag and softens relationship recovery gains', () => {
+  const state = makeState();
+
+  state.round = 1;
+  state.metrics.relationships = 30;
+  const consequences = applyRoundConsequences(state);
+  assert.ok(consequences.includes('trust-deficit'));
+  assert.equal(state.metrics.compliance, 47);
+
+  applyEffects(state, { relationships: 10 }, {
+    type: 'task',
+    id: 'relationship-repair',
+    title: 'Relationship Repair',
+    option: 'Intensive outreach',
+    round: 1,
+  });
+
+  assert.equal(state.metrics.relationships, 35);
+});
+
+test('audit escalation triggers after two consecutive low-compliance rounds', () => {
+  const state = makeState();
+
+  state.round = 1;
+  state.metrics.compliance = 38;
+  let consequences = applyRoundConsequences(state);
+  assert.deepEqual(consequences, []);
+
+  state.round = 2;
+  state.metrics.compliance = 35;
+  consequences = applyRoundConsequences(state);
+  assert.ok(consequences.includes('audit-escalation'));
+  assert.equal(state.metrics.progress, 46);
+  assert.equal(state.metrics.budget, 44);
+});


### PR DESCRIPTION
### Motivation
- Prevent long-term metric stagnation and add meaningful downside spirals when key metrics stay low by applying threshold-triggered consequences each round.
- Make automated balance tests reflect those downside dynamics so tuning and playtests reveal trade-offs more clearly.

### Description
- Add constants and a new `applyRoundConsequences(state)` function in `js/engine.js` to track streaks and trigger penalties for sustained low `budget`, `relationships`, and `compliance` (contractor attrition, trust-deficit drag, audit escalation). 
- Reduce positive relationship gains while `trustDeficitActive` by dampening relationship deltas in `applyEffects` (softens single-round recovery). 
- Wire `applyRoundConsequences` into the CLI simulation loop in `cli.mjs` and the strategy sweep in `test_strategies.js` so simulated runs include round consequences. 
- Add unit tests at `tests/roundConsequences.test.mjs` that validate contractor attrition, trust-deficit behavior, and audit escalation triggers.

### Testing
- Ran `node tests/endConditions.test.mjs` and all existing end-condition tests passed. 
- Ran `node tests/roundConsequences.test.mjs` and the new regression tests passed. 
- Ran `node test_strategies.js` to sweep role/area combinations and observed the intended metric spreads. 
- Ran `node cli.mjs --runs 5 --rounds 4 --log` to exercise CLI simulation with logs and inspected outcomes. 
- Built the site with `npm run build` successfully. 
- Attempted `npx playwright test` but the Playwright install was blocked by a registry policy (`403 Forbidden`), so Playwright integration tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2ea593320833188924c013647a0d5)