### PR TITLE
Consolidate seasonal TUI response options into one panel

### DIFF
--- a/js/engine/assignments.js
+++ b/js/engine/assignments.js
@@ -377,7 +377,8 @@ function buildBriefingCandidates(state, context) {
     sourceKey: `finding:${index}`,
     title: familyTitle(context.roleId, "briefing"),
     description: sanitizeText(finding),
-    flavor: sanitizeText(context?.briefing?.zoneSummary),
+    // The zone summary is standing area context — it now lives in the
+    // Dashboard "Area" tab, so the per-turn card keeps just its finding.
     sourceLabel: SOURCE_LABELS.briefing,
     whyNow: sanitizeText(
       context?.briefing?.seasonalSignals?.[Math.max(0, context.round - 1)]

--- a/js/engine/seasonalContract.js
+++ b/js/engine/seasonalContract.js
@@ -245,10 +245,18 @@ function inferDecisionPrompt(type, riskClass, context) {
   if (type === "temptation") {
     return "Decide whether to refuse, report, or take a shortcut that could damage the file if it comes back on you.";
   }
-  if (riskClass === "calculated") {
-    return `Choose the response that protects ${String(context?.objective || "the job").toLowerCase()} without creating a larger follow-up problem.`;
+  // Objectives are written as imperative sentences ("Build a work program..."),
+  // so introduce them with a colon rather than splicing them mid-sentence — and
+  // strip any trailing period so we don't double-punctuate.
+  const objective = String(context?.objective || "").trim().replace(/\s*[.]+\s*$/, "");
+  if (objective) {
+    return riskClass === "calculated"
+      ? `Choose the response that protects this objective without a larger follow-up problem: ${objective}.`
+      : `Choose the response that best protects this objective: ${objective}.`;
   }
-  return `Choose the response that best protects ${String(context?.objective || "the current work").toLowerCase()}.`;
+  return riskClass === "calculated"
+    ? "Choose the response that protects the work without creating a larger follow-up problem."
+    : "Choose the response that best protects the current work.";
 }
 
 function rewriteAmbiguousTerminology(text) {

--- a/js/engine/seasonalContract.js
+++ b/js/engine/seasonalContract.js
@@ -245,18 +245,10 @@ function inferDecisionPrompt(type, riskClass, context) {
   if (type === "temptation") {
     return "Decide whether to refuse, report, or take a shortcut that could damage the file if it comes back on you.";
   }
-  // Objectives are written as imperative sentences ("Build a work program..."),
-  // so introduce them with a colon rather than splicing them mid-sentence — and
-  // strip any trailing period so we don't double-punctuate.
-  const objective = String(context?.objective || "").trim().replace(/\s*[.]+\s*$/, "");
-  if (objective) {
-    return riskClass === "calculated"
-      ? `Choose the response that protects this objective without a larger follow-up problem: ${objective}.`
-      : `Choose the response that best protects this objective: ${objective}.`;
-  }
-  return riskClass === "calculated"
-    ? "Choose the response that protects the work without creating a larger follow-up problem."
-    : "Choose the response that best protects the current work.";
+  // There is no per-card authored question, and the role/season objective is
+  // generic, so asking a grounded question that points at the briefing above
+  // reads better than splicing in a goal that doesn't match this situation.
+  return "How do you want to respond?";
 }
 
 function rewriteAmbiguousTerminology(text) {

--- a/src/tui-browser/App.jsx
+++ b/src/tui-browser/App.jsx
@@ -444,7 +444,7 @@ function OptionsPanel({ options, optionDetails, heading, tone, selected, onSelec
       </div>
       <div className="tui-options-list">
         {options.map((label, index) => {
-          const outcome = optionDetails?.[index]?.outcome;
+          const text = optionDetails?.[index]?.outcome || label;
           return (
             <button
               key={`${label}-${index}`}
@@ -452,11 +452,8 @@ function OptionsPanel({ options, optionDetails, heading, tone, selected, onSelec
               className={`tui-option ${index === selected ? "selected" : ""}`}
               onClick={() => onSelect(index)}
             >
-              <span className="tui-option-head">
-                <span className="tui-option-number">{index + 1}</span>
-                <span className="tui-option-label">{label}</span>
-              </span>
-              {outcome ? <span className="tui-option-outcome">{outcome}</span> : null}
+              <span className="tui-option-number">{index + 1}</span>
+              <span className="tui-option-label">{text}</span>
             </button>
           );
         })}

--- a/src/tui-browser/App.jsx
+++ b/src/tui-browser/App.jsx
@@ -492,7 +492,7 @@ function CardContext({ data }) {
   );
 }
 
-function OptionsPanel({ options, optionDetails, heading, tone, selected, onSelect, isCrisis }) {
+function OptionsPanel({ options, optionDetails, heading, tone, selected, onSelect, isCrisis, situation }) {
   if (!options.length) return null;
 
   const toneClass =
@@ -505,9 +505,16 @@ function OptionsPanel({ options, optionDetails, heading, tone, selected, onSelec
         <span className={`tui-options-prompt ${toneClass ? `tone-${toneClass}` : ""}`}>{title}</span>
         <span className="tui-options-hint">↑↓ · Enter</span>
       </div>
+      {situation ? (
+        <p className="tui-options-situation preserve">
+          <span className="tui-options-situation-label">Situation</span>
+          {situation}
+        </p>
+      ) : null}
       <div className="tui-options-list">
         {options.map((label, index) => {
-          const text = optionDetails?.[index]?.outcome || label;
+          const outcome = optionDetails?.[index]?.outcome;
+          const sub = outcome && outcome !== label ? outcome : null;
           return (
             <button
               key={`${label}-${index}`}
@@ -516,7 +523,10 @@ function OptionsPanel({ options, optionDetails, heading, tone, selected, onSelec
               onClick={() => onSelect(index)}
             >
               <span className="tui-option-number">{index + 1}</span>
-              <span className="tui-option-label">{text}</span>
+              <span className="tui-option-body">
+                <span className="tui-option-label">{label}</span>
+                {sub ? <span className="tui-option-outcome">{sub}</span> : null}
+              </span>
             </button>
           );
         })}
@@ -628,6 +638,7 @@ export default function App() {
               selected={state.selected}
               onSelect={selectOption}
               isCrisis={isCrisis}
+              situation={state.contentData?.description}
             />
           </div>
         </div>

--- a/src/tui-browser/App.jsx
+++ b/src/tui-browser/App.jsx
@@ -216,12 +216,6 @@ function ScenarioAsciiMap({ map, features }) {
 
 function ContentView({ data }) {
   if (!data) return null;
-  const optionToneClass =
-    data.optionTone === "danger"
-      ? "red"
-      : data.optionTone === "warning"
-        ? "yellow"
-        : "blue";
 
   if (data.type === "message") {
     return (
@@ -348,17 +342,6 @@ function ContentView({ data }) {
             </div>
           </>
         ) : null}
-        <div className={`tui-subheading ${data.optionTone ? `tone-${optionToneClass}` : ""}`}>
-          {data.optionHeading || "Choose your response"}
-        </div>
-        <div className="tui-detail-list">
-          {data.optionDetails.map((option, idx) => (
-            <div className="tui-detail-item" key={`${option.label}-${idx}`}>
-              <div className={`tui-detail-label ${data.optionTone ? `tone-${optionToneClass}` : ""}`}>{`${idx + 1}. ${option.label}`}</div>
-              {option.outcome ? <div className="tui-detail-copy">{option.outcome}</div> : null}
-            </div>
-          ))}
-        </div>
       </div>
     );
   }
@@ -446,23 +429,37 @@ function CardContext({ data }) {
   );
 }
 
-function OptionsPanel({ options, selected, onSelect, isCrisis }) {
+function OptionsPanel({ options, optionDetails, heading, tone, selected, onSelect, isCrisis }) {
   if (!options.length) return null;
+
+  const toneClass =
+    tone === "danger" ? "red" : tone === "warning" ? "yellow" : tone ? "blue" : "";
+  const title = heading || (isCrisis ? "Command Menu" : "Options");
 
   return (
     <section className="tui-panel tui-options">
-      <div className="tui-panel-title">{isCrisis ? "Command Menu" : "Options"} (Use Arrow Keys & Enter)</div>
+      <div className="tui-panel-title">
+        <span className={toneClass ? `tone-${toneClass}` : ""}>{title}</span>
+        <span className="tui-options-hint">↑↓ · Enter</span>
+      </div>
       <div className="tui-options-list">
-        {options.map((label, index) => (
-          <button
-            key={`${label}-${index}`}
-            type="button"
-            className={`tui-option ${index === selected ? "selected" : ""}`}
-            onClick={() => onSelect(index)}
-          >
-            {` ${index + 1}. ${label} `}
-          </button>
-        ))}
+        {options.map((label, index) => {
+          const outcome = optionDetails?.[index]?.outcome;
+          return (
+            <button
+              key={`${label}-${index}`}
+              type="button"
+              className={`tui-option ${index === selected ? "selected" : ""}`}
+              onClick={() => onSelect(index)}
+            >
+              <span className="tui-option-head">
+                <span className="tui-option-number">{index + 1}</span>
+                <span className="tui-option-label">{label}</span>
+              </span>
+              {outcome ? <span className="tui-option-outcome">{outcome}</span> : null}
+            </button>
+          );
+        })}
       </div>
     </section>
   );
@@ -565,6 +562,9 @@ export default function App() {
             ) : null}
             <OptionsPanel
               options={state.options}
+              optionDetails={state.contentData?.optionDetails}
+              heading={state.contentData?.optionHeading}
+              tone={state.contentData?.optionTone}
               selected={state.selected}
               onSelect={selectOption}
               isCrisis={isCrisis}

--- a/src/tui-browser/App.jsx
+++ b/src/tui-browser/App.jsx
@@ -2,6 +2,15 @@ import { useEffect, useRef, useState } from "react";
 
 import { useGameFlow } from "../../tui/useGameFlow";
 import { renderMapsciiFrame } from "../../js/scene/mapscii/index.js";
+
+// Findings are authored as sentence fragments ("peatland edges, ..."), which
+// read fine mid-sentence but look wrong when they lead a line. Capitalize the
+// first letter for standalone display without touching the source data.
+function leadCapitalize(text) {
+  const str = String(text ?? "");
+  return str.replace(/^(\s*)(\p{L})/u, (_, space, letter) => space + letter.toUpperCase());
+}
+
 function toKeyInput(domEvent) {
   const map = {
     ArrowUp: "up",
@@ -393,7 +402,7 @@ function ContentView({ data }) {
             </div>
           </div>
         ) : null}
-        <p className="tui-copy preserve">{data.description}</p>
+        <p className="tui-copy preserve">{leadCapitalize(data.description)}</p>
         <CardContext data={data} />
         {data.type === "scenario" && data.intelLines?.length ? (
           <>
@@ -508,7 +517,7 @@ function OptionsPanel({ options, optionDetails, heading, tone, selected, onSelec
       {situation ? (
         <p className="tui-options-situation preserve">
           <span className="tui-options-situation-label">Situation</span>
-          {situation}
+          {leadCapitalize(situation)}
         </p>
       ) : null}
       <div className="tui-options-list">

--- a/src/tui-browser/App.jsx
+++ b/src/tui-browser/App.jsx
@@ -308,8 +308,9 @@ function ContentView({ data }) {
     return (
       <div className="tui-content-stack">
         <NoticeBlock notice={data.notice} />
-        {data.sourceLabel ? <div className="tui-source-label">{data.sourceLabel}</div> : null}
-        {data.cardLabel ? <div className="tui-source-label">{data.cardLabel}</div> : null}
+        {data.sourceLabel || data.cardLabel ? (
+          <div className="tui-source-label">{data.sourceLabel || data.cardLabel}</div>
+        ) : null}
         {data.phaseLabel ? <div className="tui-source-label tone-yellow">{data.phaseLabel}</div> : null}
         <div className="tui-heading">{data.title}</div>
         {data.type === "scenario" ? (

--- a/src/tui-browser/App.jsx
+++ b/src/tui-browser/App.jsx
@@ -440,7 +440,7 @@ function OptionsPanel({ options, optionDetails, heading, tone, selected, onSelec
   return (
     <section className="tui-panel tui-options">
       <div className="tui-panel-title">
-        <span className={toneClass ? `tone-${toneClass}` : ""}>{title}</span>
+        <span className={`tui-options-prompt ${toneClass ? `tone-${toneClass}` : ""}`}>{title}</span>
         <span className="tui-options-hint">↑↓ · Enter</span>
       </div>
       <div className="tui-options-list">
@@ -561,7 +561,7 @@ export default function App() {
             <OptionsPanel
               options={state.options}
               optionDetails={state.contentData?.optionDetails}
-              heading={state.contentData?.optionHeading}
+              heading={state.contentData?.decisionPrompt || state.contentData?.optionHeading}
               tone={state.contentData?.optionTone}
               selected={state.selected}
               onSelect={selectOption}

--- a/src/tui-browser/App.jsx
+++ b/src/tui-browser/App.jsx
@@ -37,7 +37,40 @@ function Header({ onExit, isCrisis }) {
   );
 }
 
+function AreaBriefing({ briefing, areaName }) {
+  const finds = briefing?.likelyFinds || [];
+  const signals = briefing?.seasonalSignals || [];
+  return (
+    <div className="tui-dashboard-body tui-area-briefing">
+      {areaName ? <div className="tui-heading">{areaName}</div> : null}
+      {briefing?.zoneSummary ? <p className="tui-copy dim preserve">{briefing.zoneSummary}</p> : null}
+      {finds.length ? (
+        <>
+          <div className="tui-subheading">What you'll likely hit</div>
+          <ul className="tui-area-list">
+            {finds.map((find, idx) => (
+              <li className="tui-copy preserve" key={`find-${idx}`}>{find}</li>
+            ))}
+          </ul>
+        </>
+      ) : null}
+      {signals.length ? (
+        <>
+          <div className="tui-subheading">Seasonal signals</div>
+          <ul className="tui-area-list">
+            {signals.map((signal, idx) => (
+              <li className="tui-copy dim preserve" key={`signal-${idx}`}>{signal}</li>
+            ))}
+          </ul>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
 function Dashboard({ gameState }) {
+  const [tab, setTab] = useState("status");
+
   const rows = !gameState
     ? [{ label: "Status", value: "Awaiting game start..." }]
     : [
@@ -54,19 +87,48 @@ function Dashboard({ gameState }) {
         { label: "Area", value: gameState.area?.name, plain: true },
       ].filter((row) => row.value !== undefined && row.value !== null);
 
+  const briefing = gameState?.areaBriefing;
+  const hasBriefing = Boolean(
+    briefing && (briefing.zoneSummary || briefing.likelyFinds?.length || briefing.seasonalSignals?.length)
+  );
+  // Fall back to Status whenever there's no area context to show (e.g. setup,
+  // or a reset that clears the briefing while the tab was left on "area").
+  const activeTab = tab === "area" && hasBriefing ? "area" : "status";
+
   return (
     <aside className="tui-panel tui-dashboard">
-      <div className="tui-panel-title">Dashboard</div>
-      <div className="tui-dashboard-body">
-        {rows.map((row) => (
-          <div className="tui-dashboard-row" key={row.label}>
-            <span className="tui-dashboard-label">{row.label}</span>
-            <span className={`tui-dashboard-value ${row.tone ? `tone-${row.tone}` : ""}`}>
-              {row.plain ? row.value : typeof row.value === "number" ? row.value : row.value}
-            </span>
-          </div>
-        ))}
+      <div className="tui-panel-title tui-dashboard-tabs">
+        <button
+          type="button"
+          className={`tui-dashboard-tab ${activeTab === "status" ? "active" : ""}`}
+          onClick={() => setTab("status")}
+        >
+          Dashboard
+        </button>
+        {hasBriefing ? (
+          <button
+            type="button"
+            className={`tui-dashboard-tab ${activeTab === "area" ? "active" : ""}`}
+            onClick={() => setTab("area")}
+          >
+            Area
+          </button>
+        ) : null}
       </div>
+      {activeTab === "area" ? (
+        <AreaBriefing briefing={briefing} areaName={gameState?.area?.name} />
+      ) : (
+        <div className="tui-dashboard-body">
+          {rows.map((row) => (
+            <div className="tui-dashboard-row" key={row.label}>
+              <span className="tui-dashboard-label">{row.label}</span>
+              <span className={`tui-dashboard-value ${row.tone ? `tone-${row.tone}` : ""}`}>
+                {row.plain ? row.value : typeof row.value === "number" ? row.value : row.value}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
     </aside>
   );
 }

--- a/src/tui-browser/styles.css
+++ b/src/tui-browser/styles.css
@@ -42,7 +42,7 @@ body {
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  padding: 0.75rem 0.95rem;
+  padding: 0.5rem 0.95rem;
   background: linear-gradient(90deg, rgba(45, 80, 22, 0.95), rgba(13, 17, 23, 0.96));
   border-bottom: 1px solid rgba(86, 212, 221, 0.28);
   box-shadow: 0 1px 0 rgba(0, 0, 0, 0.65), 0 0 36px rgba(63, 185, 80, 0.08) inset;
@@ -680,17 +680,18 @@ body {
   }
 
   .tui-header {
-    flex-wrap: wrap;
     align-items: center;
-    padding: 0.75rem;
+    padding: 0.4rem 0.75rem;
   }
 
   .tui-header-actions {
-    width: 100%;
-    margin-left: 0;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
+    margin-left: auto;
+    gap: 0.5rem;
+  }
+
+  /* Keyboard hint is meaningless on touch — reclaim the row it forced. */
+  .tui-header-help {
+    display: none;
   }
 
   .tui-dashboard {

--- a/src/tui-browser/styles.css
+++ b/src/tui-browser/styles.css
@@ -507,12 +507,23 @@ body {
 
 .tui-options .tui-panel-title {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   justify-content: space-between;
-  gap: 0.75rem;
+  gap: 0.35rem 0.75rem;
+  flex-wrap: wrap;
+}
+
+.tui-options-prompt {
+  flex: 1 1 12rem;
+  min-width: 0;
+  font-weight: 600;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
 }
 
 .tui-options-hint {
+  flex: 0 0 auto;
+  white-space: nowrap;
   font-weight: 400;
   font-size: 0.78rem;
   letter-spacing: 0.04em;

--- a/src/tui-browser/styles.css
+++ b/src/tui-browser/styles.css
@@ -528,8 +528,8 @@ body {
 
 .tui-option {
   display: flex;
-  flex-direction: column;
-  gap: 0.3rem;
+  align-items: flex-start;
+  gap: 0.55rem;
   border: 1px solid transparent;
   background: transparent;
   color: #c9d1d9;
@@ -540,12 +540,6 @@ body {
   cursor: pointer;
 }
 
-.tui-option-head {
-  display: flex;
-  align-items: baseline;
-  gap: 0.55rem;
-}
-
 .tui-option-number {
   flex: 0 0 auto;
   min-width: 1.5rem;
@@ -554,19 +548,12 @@ body {
   border: 1px solid rgba(88, 166, 255, 0.55);
   color: #58a6ff;
   font-size: 0.85rem;
+  line-height: 1.5;
 }
 
 .tui-option-label {
-  font-weight: 700;
   color: inherit;
-  overflow-wrap: anywhere;
-}
-
-.tui-option-outcome {
-  padding-left: 2.05rem;
-  color: #7d8590;
-  font-size: 0.85rem;
-  line-height: 1.45;
+  line-height: 1.5;
   overflow-wrap: anywhere;
 }
 

--- a/src/tui-browser/styles.css
+++ b/src/tui-browser/styles.css
@@ -157,6 +157,50 @@ body {
   overflow-wrap: anywhere;
 }
 
+.tui-dashboard-tabs {
+  display: flex;
+  gap: 0.25rem;
+  padding: 0;
+  align-items: stretch;
+}
+
+.tui-dashboard-tab {
+  appearance: none;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: #7d8590;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+  padding: 0.45rem 0.6rem;
+}
+
+.tui-dashboard-tab:hover {
+  color: #e6edf3;
+}
+
+.tui-dashboard-tab.active {
+  color: #e6edf3;
+  border-bottom-color: #3fb950;
+}
+
+.tui-area-briefing .tui-heading {
+  font-size: 0.95rem;
+}
+
+.tui-area-list {
+  margin: 0.15rem 0 0;
+  padding-left: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.tui-area-list li {
+  list-style: square;
+}
+
 .tone-yellow {
   color: #d29922;
 }

--- a/src/tui-browser/styles.css
+++ b/src/tui-browser/styles.css
@@ -505,22 +505,69 @@ body {
   border-color: #58a6ff;
 }
 
+.tui-options .tui-panel-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.tui-options-hint {
+  font-weight: 400;
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+  color: #7d8590;
+}
+
 .tui-options-list {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.4rem;
   padding: 0.6rem 0.75rem 0.75rem;
 }
 
 .tui-option {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
   border: 1px solid transparent;
   background: transparent;
-  color: #7d8590;
+  color: #c9d1d9;
   width: 100%;
   text-align: left;
   font: inherit;
-  padding: 0.5rem 0.55rem;
+  padding: 0.55rem 0.6rem;
   cursor: pointer;
+}
+
+.tui-option-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.55rem;
+}
+
+.tui-option-number {
+  flex: 0 0 auto;
+  min-width: 1.5rem;
+  padding: 0 0.25rem;
+  text-align: center;
+  border: 1px solid rgba(88, 166, 255, 0.55);
+  color: #58a6ff;
+  font-size: 0.85rem;
+}
+
+.tui-option-label {
+  font-weight: 700;
+  color: inherit;
+  overflow-wrap: anywhere;
+}
+
+.tui-option-outcome {
+  padding-left: 2.05rem;
+  color: #7d8590;
+  font-size: 0.85rem;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
 }
 
 .tui-option:hover {
@@ -531,6 +578,11 @@ body {
   background: #3d5a1f;
   color: #e6edf3;
   border-color: #56d4dd;
+}
+
+.tui-option.selected .tui-option-number {
+  border-color: #56d4dd;
+  color: #e6edf3;
 }
 
 .tui-overlay {

--- a/src/tui-browser/styles.css
+++ b/src/tui-browser/styles.css
@@ -606,10 +606,48 @@ body {
   line-height: 1.5;
 }
 
+.tui-option-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
 .tui-option-label {
   color: inherit;
+  font-weight: 600;
   line-height: 1.5;
   overflow-wrap: anywhere;
+}
+
+.tui-option-outcome {
+  color: #8b949e;
+  font-size: 0.85rem;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.tui-option.selected .tui-option-outcome {
+  color: #c9d1d9;
+}
+
+.tui-options-situation {
+  margin: 0;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid rgba(88, 166, 255, 0.25);
+  color: #8b949e;
+  font-size: 0.85rem;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.tui-options-situation-label {
+  color: #56d4dd;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 0.72rem;
+  margin-right: 0.5rem;
 }
 
 .tui-option:hover {

--- a/tests/tuiController.test.mjs
+++ b/tests/tuiController.test.mjs
@@ -155,7 +155,7 @@ test('first playable seasonal card exposes the contract fields and neutral promp
   assert.ok(state.contentData.context?.operation);
   assert.ok(state.contentData.context?.objective);
   assert.ok(state.contentData.context?.stakes);
-  assert.match(state.contentData.decisionPrompt || '', /^Choose the response/i);
+  assert.match(state.contentData.decisionPrompt || '', /^How do you want to respond\?$/i);
   assert.equal(state.contentData.optionHeading, 'Choose your response');
   assert.equal(state.art, null);
   assert.ok(state.options.length > 1);

--- a/tui/controller.js
+++ b/tui/controller.js
@@ -1,4 +1,4 @@
-import { FORESTER_ROLES, OPERATING_AREAS } from "../js/data/index.js";
+import { FORESTER_ROLES, OPERATING_AREAS, getRoleAreaBriefing } from "../js/data/index.js";
 import {
   buildSeasonContext,
   createInitialState,
@@ -139,6 +139,12 @@ function snapshotGameState(gs) {
         }
       : null,
     roleDisplayName: gs.roleDisplayName || getRoleDisplayName(gs.role),
+    // Standing role-area context for the Dashboard "Area" tab. It's a pure
+    // function of role + area, so recompute it from the snapshot rather than
+    // threading it through every season's state.
+    areaBriefing: gs.role?.id && gs.area
+      ? getRoleAreaBriefing(gs.role.id, gs.area, { maxFinds: 6 })
+      : null,
   };
 }
 


### PR DESCRIPTION
The decision options were rendered twice: a static 'Choose your response'
list inside the card (label + outcome) and the interactive 'Options (Use
Arrow Keys & Enter)' buttons below (labels only). On mobile you scrolled
past the same three options twice.

Merge them into a single interactive Options panel: each selectable option
now shows a numbered badge, its label, and its outcome preview inline, and
the panel carries the card's heading (e.g. 'Choose your response') and
tone. Remove the duplicate static list from the card so it ends at the
description and on-demand context.

Outcomes stay visible for every option (a tap executes immediately, so
there is no hover-to-preview affordance on touch).