### PR TITLE
Make the first five minutes legible: objectives, gated events, grouped menus

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
     <title>BC Forestry Trail — Expedition Mode</title>
@@ -62,7 +62,9 @@
               <span class="btn-icon">#</span>
               <span class="btn-text">[T] SEASONAL STRATEGY</span>
             </button>
-            <button id="crisis-mode-btn" class="landing-btn secondary experimental" type="button">
+            <!-- Experimental: hidden until the core loop is solid. Opt in with
+                 ?experimental=1 or localStorage forestExperimental=1. -->
+            <button id="crisis-mode-btn" class="landing-btn secondary experimental" type="button" hidden>
               <span class="btn-icon">!</span>
               <span class="btn-text">[C]RISIS COMMAND</span>
               <span class="landing-btn-badge">EXPERIMENTAL</span>
@@ -224,24 +226,24 @@
       <div id="modern-stats-row" class="modern-stats-row">
         <div class="modern-stat-card">
           <span class="stat-card-label">CURRENT YEAR</span>
-          <span class="stat-card-value" id="modern-year-value">2025</span>
+          <span class="stat-card-value" id="modern-year-value">—</span>
         </div>
         <div class="modern-stat-card">
           <span class="stat-card-label">FUNDS</span>
-          <span class="stat-card-value" id="modern-funds-value">$80,000</span>
+          <span class="stat-card-value" id="modern-funds-value">—</span>
         </div>
         <div class="modern-stat-card">
           <span class="stat-card-label">ECO-HEALTH</span>
           <div class="stat-card-progress">
-            <span class="stat-card-value" id="modern-eco-value">85%</span>
-            <div class="stat-card-bar"><div class="stat-card-fill" id="modern-eco-fill" style="width: 85%"></div></div>
+            <span class="stat-card-value" id="modern-eco-value">—</span>
+            <div class="stat-card-bar"><div class="stat-card-fill" id="modern-eco-fill" style="width: 0%"></div></div>
           </div>
         </div>
         <div class="modern-stat-card">
           <span class="stat-card-label">ZONE</span>
           <div class="stat-card-zone">
             <span class="zone-icon">🌲</span>
-            <span class="stat-card-value" id="modern-zone-value">Sub-Boreal Spruce</span>
+            <span class="stat-card-value" id="modern-zone-value">—</span>
           </div>
         </div>
       </div>

--- a/js/game/ForestryTrailGame.js
+++ b/js/game/ForestryTrailGame.js
@@ -7,7 +7,7 @@
 
 import { TerminalUI } from '../ui.js';
 import { FORESTER_ROLES, OPERATING_AREAS } from '../data/index.js';
-import { generateCrew, processDailyUpdate, getCrewDisplayInfo } from '../crew.js';
+import { generateCrew, getCrewDisplayInfo } from '../crew.js';
 import {
   createJourney,
   formatJourneyLog,
@@ -362,70 +362,6 @@ export class ForestryTrailGame {
 
   async _handleEvent(event) {
     await handleEvent(this, event);
-  }
-
-  _displayCrewStatus() {
-    const activeCrew = this.journey.crew.filter(m => m.isActive);
-    const activeCount = activeCrew.length;
-    const totalCount = this.journey.crew.length;
-    const avgHealth = activeCount > 0
-      ? Math.round(activeCrew.reduce((sum, m) => sum + m.health, 0) / activeCount)
-      : 0;
-    const injured = activeCrew.filter(m => m.statusEffects?.length > 0).length;
-
-    this.ui.write(`Crew: ${activeCount}/${totalCount} active | Avg Health: ${avgHealth}%${injured > 0 ? ` | ${injured} injured` : ''}`);
-    this.ui.write('(Crew details: the [S] Status button, or press S)');
-    this.ui.write('');
-  }
-
-  _getDeskPhase(journey) {
-    const day = journey.day;
-    const deadline = journey.deadline || 30;
-    const phaseLength = Math.max(1, Math.floor(deadline / 3));
-
-    if (day > deadline - 4) return 'crunch';
-    if (day > phaseLength * 2) return 'approval';
-    if (day > phaseLength) return 'review';
-    return 'planning';
-  }
-
-  _miniBar(value, width = 5) {
-    const filled = Math.round((value / 100) * width);
-    return '█'.repeat(filled) + '░'.repeat(width - filled);
-  }
-
-  _updateCrewConditions() {
-    const journey = this.journey;
-    const conditions = {
-      restDay: journey.journeyType === 'desk' || journey.pace === 'resting',
-      gruelingPace: journey.pace === 'grueling',
-      lowFood: journey.journeyType === 'field' ? journey.resources.food <= 0 : false,
-      coldWeather: journey.journeyType === 'field' && (journey.temperature === 'cold' || journey.temperature === 'freezing'),
-      shelter: journey.journeyType === 'desk'
-    };
-
-    for (const member of journey.crew) {
-      if (!member.isActive) continue;
-
-      const wasAlive = !member.isDead;
-      const wasActive = !member.hasQuit;
-
-      const update = processDailyUpdate(member, conditions);
-
-      if (wasAlive && member.isDead) {
-        this.ui.writeWarning(`${member.name} has died from their injuries!`);
-      } else if (wasActive && member.hasQuit) {
-        this.ui.writeWarning(`${member.name} has had enough and quit the expedition!`);
-      }
-
-      if (update.messages && update.messages.length > 0) {
-        for (const msg of update.messages) {
-          this.ui.write(msg);
-        }
-      }
-    }
-
-    this.ui.updateAllStatus(journey);
   }
 
   _checkEndConditions() {

--- a/js/modes/manager.js
+++ b/js/modes/manager.js
@@ -44,7 +44,8 @@ export async function runManagerDay(game) {
 
   // The day's event, drawn through the real selection pipeline (cooldowns,
   // context matching, scrutiny/difficulty modifiers, reporter attachment).
-  const event = checkForEvent(journey);
+  // The opening month is event-free so the executive loop reads cleanly first.
+  const event = journey.day > 1 ? checkForEvent(journey) : null;
   if (event) {
     displayManagerHeader(ui, journey);
     await handleEvent(game, event);
@@ -162,6 +163,11 @@ function displayManagerHeader(ui, journey) {
     ui.write(`Executive Crew: ${activeCrew.length} active | Avg Morale: ${avgMorale}%`);
   }
 
+  // Sticky objective + the two survival gates the term victory check uses.
+  const budgetOk = journey.resources.budget > 0;
+  const repOk = (journey.metrics.reputation || 50) > 40;
+  ui.write(`Objective: Lead the company through all ${journey.deadline} months with the books and the board onside.`);
+  ui.write(`Survival Gates: [${budgetOk ? 'x' : ' '}] Solvent  [${repOk ? 'x' : ' '}] Reputation above 40%`);
   ui.write(`Term Progress: ${getOperationalProgress(journey)}%`);
   ui.write("");
 }

--- a/js/modes/permitting.js
+++ b/js/modes/permitting.js
@@ -497,17 +497,6 @@ function buildPermittingActionGuidance(journey) {
   return { lane, headline, steps };
 }
 
-function getDeskActionLaneLabel(actionId) {
-  const labels = {
-    process_permits: 'Lane: review support',
-    stakeholder_meeting: 'Lane: consultation support',
-    crisis_management: 'Lane: crisis desk',
-    team_morale: 'Lane: office recovery',
-    end_day: 'Lane: recovery'
-  };
-  return labels[actionId] || 'Lane: support';
-}
-
 function formatConstraintPressure(state) {
   return `Engineering ${state?.engineering || 0}/4 | FOM/Public Review ${state?.publicReview || 0}/4 | Hydrology ${state?.hydrology || 0}/4 | Water Timing ${state?.timing || 0}/4`;
 }
@@ -791,8 +780,9 @@ export async function runPermittingDay(game) {
   let meetingsToday = 0;
   let crisisMode = daysRemaining <= 5;
 
-  // Check for random event at start of day
-  const event = checkForEvent(journey);
+  // Check for random event at start of day. Day 1 is event-free onboarding so
+  // the player sees the normal permitting loop before any exception arrives.
+  const event = journey.day > 1 ? checkForEvent(journey) : null;
   if (event) {
     ui.clear();
     ui.writeHeader(`DAY ${journey.day} of ${journey.deadline} - ${(journey.currentPhase || 'PERMITTING').toUpperCase()}`);
@@ -816,10 +806,30 @@ export async function runPermittingDay(game) {
       break;
     }
 
-    const actionOptions = buildActionOptions(journey);
+    const { primary, support } = buildActionOptions(journey);
 
-    const action = await ui.promptChoice(`${journey.hoursRemaining} hours remaining:`, actionOptions);
-    const actionId = action.value || 'end_day';
+    // Resolve the menu, drilling into the support submenu when chosen — the same
+    // shape recon uses, so the primary turn stays a clean set of decisions.
+    let actionId = 'end_day';
+    while (true) {
+      const action = await ui.promptChoice(`${journey.hoursRemaining} hours remaining:`, primary);
+      const chosen = action.value || 'end_day';
+      if (chosen === 'support_menu') {
+        const sub = await ui.promptChoice('Office & support:', [
+          ...support,
+          { label: 'Back', description: 'Return to the main menu', value: 'support_back' }
+        ]);
+        const subChoice = sub.value || 'support_back';
+        if (subChoice === 'support_back') {
+          displayPermittingHeader(ui, journey);
+          continue;
+        }
+        actionId = subChoice;
+        break;
+      }
+      actionId = chosen;
+      break;
+    }
 
     // End day early
     if (actionId === 'end_day') {
@@ -852,6 +862,8 @@ export async function runPermittingDay(game) {
  */
 function displayPermittingHeader(ui, journey) {
   const daysRemaining = Math.max(0, journey.deadline - journey.day);
+  const guidance = buildPermittingActionGuidance(journey);
+  const laneAction = getPermittingLaneAction(journey);
   ui.clear();
   ui.writeHeader(`DAY ${journey.day} of ${journey.deadline} - PERMITTING`);
 
@@ -865,6 +877,11 @@ function displayPermittingHeader(ui, journey) {
 
   const permitProgress = Math.round((journey.permits.approved / journey.permits.target) * 100);
   ui.write(`Pipeline: Backlog ${journey.permits.backlog || 0} | Drafting ${journey.permits.drafting || 0} | Submitted ${journey.permits.submitted} | In Review ${journey.permits.inReview} | Approved ${journey.permits.approved}/${journey.permits.target} (${permitProgress}%)`);
+  // Sticky objective block — lane, stage, and best move live here on every shift,
+  // not only behind Review the File.
+  ui.write(`Objective: Approve ${journey.permits.target} permits by Day ${journey.deadline} (${journey.permits.approved} done).`);
+  ui.write(`Lane Focus: ${guidance.lane} | Stage: ${laneAction.stageLabel}`);
+  ui.write(`Next Best Move: ${guidance.headline}`);
   ui.write(`Budget: $${Math.round(journey.resources.budget).toLocaleString()} | Political Capital: ${journey.resources.politicalCapital}`);
 
   // Alerts only — the full file lives behind Review the File
@@ -945,111 +962,145 @@ function displayPermittingBriefing(ui, journey) {
  * @returns {Array} Action options
  */
 function buildActionOptions(journey) {
-  const actionOptions = [];
   const hoursLeft = journey.hoursRemaining || 8;
   const revisionQueue = ensurePermittingRevisionState(journey);
   const laneAction = getPermittingLaneAction(journey);
 
-  // Permit-specific actions
+  // The turn is split so it reads as a decision, not an audit:
+  //   primary  = the best move + core pipeline throughput (kept ≤6)
+  //   support  = relationships, morale, crisis, recovery — one level down
+  const primary = [];
+  const support = [];
+
+  // Best move leads the menu — the lane action is always the recommended choice.
+  // Professional blockers carry a plain-English translation of the jargon.
+  if (hoursLeft >= 2) {
+    const professional = getPermittingProfessionalSnapshot(journey);
+    const pieces = [];
+    if (professional?.registrationStatus !== 'active') {
+      pieces.push(`registration ${professional.registrationStatus} (your licence to sign off is not current)`);
+    }
+    if (professional?.cpdGap > 0) {
+      pieces.push(`CPD gap ${professional.cpdGap}h (training file behind — reviewers trust submissions less)`);
+    }
+    if (professional?.paperworkLoad > 0) {
+      pieces.push(`paperwork ${professional.paperworkLoad} (filing backlog slowing the desk)`);
+    }
+    primary.push({
+      label: `${laneAction.actionLabel} (2h)`,
+      description: pieces.length
+        ? `Best move | Lane: ${laneAction.laneLabel.toLowerCase()} | Stage: ${laneAction.stageLabel} | Clears: ${pieces.join(' | ')}`
+        : `Best move | Lane: ${laneAction.laneLabel.toLowerCase()} | Stage: ${laneAction.stageLabel}`,
+      value: 'professional_admin'
+    });
+  }
+
+  // Core pipeline throughput stays top-level so the main work is never buried.
   if (journey.permits.backlog > 0 && hoursLeft >= 2) {
-    actionOptions.push({
+    primary.push({
       label: 'Draft Permit Application',
-      description: '2h - Lane: permit stack | Move a permit from backlog to drafting',
+      description: '2h - Move a permit from the backlog into drafting',
       value: 'draft_permit'
     });
   }
 
   if ((journey.permits.drafting || 0) > 0 && hoursLeft >= 2) {
-    actionOptions.push({
+    primary.push({
       label: 'Submit Permit',
-      description: '2h - Lane: submission stack | Submit a drafted permit for review',
+      description: '2h - Send a drafted permit into review',
       value: 'submit_permit'
     });
   }
 
+  // First open deficiency gets a top-level pair; extras drop into the submenu so
+  // the primary menu does not balloon when several files come back at once.
   const openRevisionTickets = revisionQueue.filter((ticket) => ticket && !ticket.resolved);
-  for (const ticket of openRevisionTickets.slice(0, 3)) {
+  openRevisionTickets.forEach((ticket, index) => {
+    const bucket = index === 0 ? primary : support;
     if (hoursLeft >= ticket.clean.hours) {
-      actionOptions.push({
+      bucket.push({
         label: `Clean response: ${ticket.title}`,
-        description: `${ticket.clean.hours}h - Lane: revision queue | cleaner file, lower scrutiny`,
+        description: `${ticket.clean.hours}h - Fix the deficiency properly; lower scrutiny`,
         value: `revise_permit:${ticket.id}:clean`
       });
     }
     if (hoursLeft >= ticket.fast.hours) {
-      actionOptions.push({
+      bucket.push({
         label: `Fast-track: ${ticket.title}`,
-        description: `${ticket.fast.hours}h - Lane: revision queue | quicker resubmission, more heat`,
+        description: `${ticket.fast.hours}h - Quicker resubmission, but more heat`,
         value: `revise_permit:${ticket.id}:fast`
       });
     }
-  }
+  });
 
-  // Referral management (permitting-specific)
   if ((journey.permits.inReferral || 0) > 0 && hoursLeft >= 2) {
-    actionOptions.push({
+    primary.push({
       label: 'Follow Up on Referrals',
-      description: '2h - Lane: referral queue | Check status with referral agencies',
+      description: '2h - Chase the other-agency sign-offs a permit is waiting on',
       value: 'follow_up_referrals'
     });
   }
 
-  if (hoursLeft >= 2) {
-    const professional = getPermittingProfessionalSnapshot(journey);
-    const label = `${laneAction.actionLabel} (2h)`;
-    const pieces = [];
-    if (professional?.registrationStatus !== 'active') {
-      pieces.push(`registration ${professional.registrationStatus}`);
-    }
-    if (professional?.cpdGap > 0) {
-      pieces.push(`CPD gap ${professional.cpdGap}h`);
-    }
-    if (professional?.paperworkLoad > 0) {
-      pieces.push(`paperwork ${professional.paperworkLoad}`);
-    }
-    actionOptions.push({
-      label,
-      description: pieces.length
-        ? `Lane: ${laneAction.laneLabel.toLowerCase()} | Stage: ${laneAction.stageLabel} | Reset: ${pieces.join(' | ')}`
-        : `Lane: ${laneAction.laneLabel.toLowerCase()} | Stage: ${laneAction.stageLabel}`,
-      value: 'professional_admin'
+  // Process Permits is core throughput — it keeps submitted files moving.
+  if (DESK_ACTIONS.process_permits.hoursRequired <= hoursLeft) {
+    primary.push({
+      label: DESK_ACTIONS.process_permits.name,
+      description: `${DESK_ACTIONS.process_permits.hoursRequired}h - ${DESK_ACTIONS.process_permits.description}`,
+      value: 'process_permits'
     });
   }
 
-  // Standard desk actions
-  const standardActions = Object.entries(DESK_ACTIONS)
-    .filter(([, action]) => action.hoursRequired <= hoursLeft)
-    .map(([id, action]) => ({
-      label: action.name,
-      description: `${action.hoursRequired}h - ${getDeskActionLaneLabel(id)} | ${action.description}`,
-      value: id
-    }));
-
-  actionOptions.push(...standardActions);
-
-  // Protagonist-specific actions
+  // Support actions: relationships, morale, crisis response, recovery.
+  if (DESK_ACTIONS.stakeholder_meeting.hoursRequired <= hoursLeft) {
+    support.push({
+      label: DESK_ACTIONS.stakeholder_meeting.name,
+      description: `${DESK_ACTIONS.stakeholder_meeting.hoursRequired}h - ${DESK_ACTIONS.stakeholder_meeting.description}`,
+      value: 'stakeholder_meeting'
+    });
+  }
+  if (DESK_ACTIONS.team_morale.hoursRequired <= hoursLeft) {
+    support.push({
+      label: DESK_ACTIONS.team_morale.name,
+      description: `${DESK_ACTIONS.team_morale.hoursRequired}h - ${DESK_ACTIONS.team_morale.description}`,
+      value: 'team_morale'
+    });
+  }
+  if (DESK_ACTIONS.crisis_management.hoursRequired <= hoursLeft) {
+    support.push({
+      label: DESK_ACTIONS.crisis_management.name,
+      description: `${DESK_ACTIONS.crisis_management.hoursRequired}h - ${DESK_ACTIONS.crisis_management.description}`,
+      value: 'crisis_management'
+    });
+  }
   if (journey.protagonist && hoursLeft >= 1) {
-    actionOptions.push({
+    support.push({
       label: 'Take a Break',
       description: '1h - Reduce stress, recover energy',
       value: 'rest'
     });
   }
 
-  actionOptions.push({
+  if (support.length > 0) {
+    primary.push({
+      label: 'Office & Support ▸',
+      description: 'Stakeholders, team morale, crisis response, and recovery',
+      value: 'support_menu'
+    });
+  }
+
+  primary.push({
     label: 'Review the File',
     description: 'Pipeline detail, pressure, relationships, and carry-forward notes',
     value: 'briefing'
   });
 
-  // Always add "End Day Early" option
-  actionOptions.push({
+  primary.push({
     label: 'End Day Early',
     description: 'Rest and start fresh tomorrow',
     value: 'end_day'
   });
 
-  return actionOptions;
+  return { primary, support };
 }
 
 function shiftPermits(sourceKey, targetKey, permits, count) {

--- a/js/modes/planning.js
+++ b/js/modes/planning.js
@@ -116,6 +116,25 @@ function getPlanningApprovalGaps(journey) {
   return gaps;
 }
 
+/**
+ * The four ministerial approval thresholds, rendered as an always-visible
+ * checklist so the player never has to guess why submission is still blocked.
+ * Mirrors isPlanningApprovalReady() in shared/endConditions.js.
+ */
+function formatPlanningApprovalGates(journey) {
+  const plan = journey?.plan || {};
+  const gates = [
+    { label: 'Data 80%', current: Math.round(plan.dataCompleteness || 0), target: 80 },
+    { label: 'Analysis 80%', current: Math.round(plan.analysisQuality || 0), target: 80 },
+    { label: 'Buy-in 75%', current: Math.round(plan.stakeholderBuyIn || 0), target: 75 },
+    { label: 'Confidence 80%', current: Math.round(plan.ministerialConfidence || 0), target: 80 }
+  ];
+  return gates.map((gate) => {
+    const met = gate.current >= gate.target;
+    return `[${met ? 'x' : ' '}] ${gate.label} (${gate.current}%)`;
+  });
+}
+
 function applyPlanningProfessionalWork(journey, changes = {}) {
   const professional = ensurePlanningProfessionalState(journey);
   if (!professional) return null;
@@ -517,8 +536,9 @@ export async function runPlanningDay(game) {
   // Apply daily values consequences (Phase 4.1)
   applyValuesConsequences(journey);
 
-  // Check for event at start of day
-  const event = checkForEvent(journey);
+  // Check for event at start of day. Day 1 stays event-free so the player meets
+  // the normal planning loop before the game starts throwing disruptions.
+  const event = journey.day > 1 ? checkForEvent(journey) : null;
   if (event) {
     displayPlanningHeader(ui, journey, seasonInfo);
     await handleEvent(game, event);
@@ -603,7 +623,13 @@ function displayPlanningHeader(ui, journey, seasonInfo) {
 
   ui.write(`Phase: ${getPlanningPhaseLabel(journey.plan.phase)}${Number.isFinite(journey.deadline) ? ` | Days left: ${Math.max(0, journey.deadline - journey.day)}` : ''}`);
   ui.write(`Data: ${journey.plan.dataCompleteness}% | Analysis: ${journey.plan.analysisQuality}% | Buy-in: ${journey.plan.stakeholderBuyIn}% | Confidence: ${journey.plan.ministerialConfidence}%`);
+  // Sticky objective block — the player should never have to dig into Review the
+  // File to learn what they are doing right now or what is still blocking them.
+  const objectiveDeadline = Number.isFinite(journey.deadline) ? ` by Day ${journey.deadline}` : '';
+  ui.write(`Objective: Win ministerial approval of the landscape plan${objectiveDeadline}.`);
+  ui.write(`Lane Focus: ${guidance.lane}`);
   ui.write(`Next Best Move: ${guidance.headline}`);
+  ui.write(`Approval Gates: ${formatPlanningApprovalGates(journey).join('  ')}`);
   ui.write(`Budget: $${journey.resources.budget.toLocaleString()} | Political Capital: ${journey.resources.politicalCapital} | Data: ${journey.resources.dataCredits}`);
 
   // Alerts only — the full file lives behind Review the File
@@ -883,19 +909,19 @@ function buildActionOptions(journey, seasonInfo = null) {
     const label = professional?.registrationActive ? 'Compliance Admin (2h)' : 'Renew Registration (2h)';
     const pieces = [];
     if (professional?.registrationStatus !== 'active') {
-      pieces.push(`registration ${professional.registrationStatus}`);
+      pieces.push(`registration ${professional.registrationStatus} (your licence to sign off is not current)`);
     }
     if (professional?.cpdGap > 0) {
-      pieces.push(`CPD gap ${professional.cpdGap}h`);
+      pieces.push(`CPD gap ${professional.cpdGap}h (professional training file is behind)`);
     }
     if (professional?.paperworkLoad > 0) {
-      pieces.push(`paperwork ${professional.paperworkLoad}`);
+      pieces.push(`paperwork ${professional.paperworkLoad} (filing backlog slowing the file)`);
     }
     actionOptions.push({
       label,
       description: pieces.length
-        ? `Lane: professional file | Reset: ${pieces.join(' | ')}`
-        : 'Lane: professional file | Renew registration, log CPD, and clear paperwork pressure',
+        ? `Lane: professional file | Clears: ${pieces.join(' | ')}`
+        : 'Lane: professional file | Renew registration, log CPD (continuing training), and clear paperwork pressure',
       value: 'professional_admin'
     });
   }

--- a/js/modes/recon.js
+++ b/js/modes/recon.js
@@ -269,8 +269,9 @@ async function runFieldDay(game) {
   // rolls over once, at the very end of the shift, via endFieldDay().
   let dayResolved = false;
 
-  // Check for random event at start of day
-  const event = checkForEvent(journey);
+  // Check for random event at start of day. The first shift teaches the base
+  // loop — no surprise event fires before the player has seen a normal turn.
+  const event = journey.day > 1 ? checkForEvent(journey) : null;
   if (event) {
     displayDayHeader(ui, journey);
     await handleEvent(game, event);
@@ -616,6 +617,13 @@ function displayDayHeader(ui, journey) {
       : '[x] values sweep (not flagged)';
     const finalized = intel.accessGroundTruthed && (!sweep.needed || intel.valuesSwept);
     ui.write(`${currentBlock.name} package: ${check(intel.accessGroundTruthed)} access  ${sweepLabel}  ${check(finalized)} finalized`);
+    // Current Intel on the shift header, not only behind Review the Briefing, so
+    // the player always knows what is still unverified on the block underfoot.
+    const accessIntelLabel = intel.accessGroundTruthed ? 'ground-truthed' : 'unverified';
+    const valuesIntelLabel = sweep.needed
+      ? (intel.valuesSwept ? 'swept' : 'pending')
+      : 'quiet';
+    ui.write(`Current Intel: access ${accessIntelLabel} | values ${valuesIntelLabel}`);
   }
   displayCrewStatus(ui, journey);
 

--- a/js/modes/silviculture.js
+++ b/js/modes/silviculture.js
@@ -127,10 +127,11 @@ export async function runSilvicultureDay(game) {
   // Apply daily overhead cost
   journey.resources.budget -= 850;
 
-  // Check for contractor event (higher when morale/productivity is slipping)
+  // Check for contractor event (higher when morale/productivity is slipping).
+  // Held back on day 1 so onboarding is not interrupted by a contractor crisis.
   const activeContractors = journey.contractors.filter(c => c.isActive);
   const contractorStress = activeContractors.some(c => c.morale < 55 || c.productivity < 60);
-  if (Math.random() < (contractorStress ? 0.40 : 0.30)) {
+  if (journey.day > 1 && Math.random() < (contractorStress ? 0.40 : 0.30)) {
     if (activeContractors.length > 0) {
       const targetContractor = activeContractors[Math.floor(Math.random() * activeContractors.length)];
       const applicableEvents = CONTRACTOR_EVENTS.filter(e => e.trigger(targetContractor));
@@ -142,8 +143,9 @@ export async function runSilvicultureDay(game) {
     }
   }
 
-  // Check for random event
-  const event = checkForEvent(journey);
+  // Check for random event. Day 1 stays event-free so the contractor loop is
+  // legible before disruptions begin.
+  const event = journey.day > 1 ? checkForEvent(journey) : null;
   if (event) {
     displaySilvicultureHeader(ui, journey, seasonInfo, silvicultureState, zoneProfile);
     await handleEvent(game, event);
@@ -250,6 +252,12 @@ function displaySilvicultureHeader(ui, journey, seasonInfo, silvicultureState, z
   const surveyPct = Math.round(Math.min(1, journey.surveys.freeGrowingComplete / journey.surveys.freeGrowingTarget) * 100);
 
   ui.write(`Plant: ${plantPct}% (${Math.min(journey.planting.blocksPlanted, journey.planting.blocksToPlant)}/${journey.planting.blocksToPlant} blocks) | Brush: ${brushPct}% | Survey: ${surveyPct}% (${Math.min(journey.surveys.freeGrowingComplete, journey.surveys.freeGrowingTarget)}/${journey.surveys.freeGrowingTarget})`);
+
+  // Sticky objective + win gates so the regen targets are never a mystery.
+  const plantDone = journey.planting.blocksPlanted >= journey.planting.blocksToPlant;
+  const surveyDone = journey.surveys.freeGrowingComplete >= journey.surveys.freeGrowingTarget;
+  ui.write(`Objective: Hit the regeneration targets — plant the block program and clear free-growing surveys.`);
+  ui.write(`Regen Gates: [${plantDone ? 'x' : ' '}] Planting (${plantPct}%)  [${surveyDone ? 'x' : ' '}] Free-growing surveys (${surveyPct}%)`);
 
   // Compact contractors
   const roster = getSilvicultureContractorRoster(journey, zoneProfile);

--- a/js/ui.js
+++ b/js/ui.js
@@ -137,6 +137,13 @@ export class TerminalUI {
     this.statCrewValue = document.getElementById('stat-crew-value');
     this.statMoraleValue = document.getElementById('stat-morale-value');
 
+    // Modern mode stats row (year / funds / eco-health / zone)
+    this.modernYearValue = document.getElementById('modern-year-value');
+    this.modernFundsValue = document.getElementById('modern-funds-value');
+    this.modernEcoValue = document.getElementById('modern-eco-value');
+    this.modernEcoFill = document.getElementById('modern-eco-fill');
+    this.modernZoneValue = document.getElementById('modern-zone-value');
+
     // Modern mode footer buttons
     this.footerGlossaryBtn = document.getElementById('footer-glossary-btn');
     this.logBtn = document.getElementById('log-btn');
@@ -272,9 +279,11 @@ export class TerminalUI {
     document.addEventListener('keydown', (e) => {
       const canUseGameplayShortcuts = this._canUseGameplayShortcuts();
 
-      // Number keys for choices (works in both classic and modern mode)
-      if (canUseGameplayShortcuts && /^[1-9]$/.test(e.key) && this._choiceHandler) {
-        const index = parseInt(e.key, 10) - 1;
+      // Number keys for choices (works in both classic and modern mode).
+      // 1-9 map directly; 0 is the accelerator for a 10th option so menus that
+      // reach ten choices are never left with an unreachable last item.
+      if (canUseGameplayShortcuts && /^[0-9]$/.test(e.key) && this._choiceHandler) {
+        const index = e.key === '0' ? 9 : parseInt(e.key, 10) - 1;
         const buttons = this.choices?.querySelectorAll('.choice-btn, .decision-card');
         if (buttons && buttons[index]) {
           e.preventDefault();

--- a/js/ui/initFlow.js
+++ b/js/ui/initFlow.js
@@ -90,6 +90,12 @@ export const InitFlowMixin = {
   _initLandingScreen() {
     if (!this.landingScreen) return;
 
+    // Experimental modes (Crisis Command) stay hidden until the core loop is
+    // solid. Reveal them only when the player explicitly opts in.
+    if (this.crisisModeBtn && this._isExperimentalEnabled()) {
+      this.crisisModeBtn.hidden = false;
+    }
+
     // New Game button
     this.newGameBtn?.addEventListener('click', () => {
       this._hideLandingScreen();
@@ -105,6 +111,9 @@ export const InitFlowMixin = {
     });
 
     this.crisisModeBtn?.addEventListener('click', () => {
+      // Stays inert while hidden so a stray programmatic click cannot launch an
+      // experimental mode the player never opted into.
+      if (this.crisisModeBtn.hidden) return;
       window.location.assign('./tui.html?mode=crisis-command');
     });
 
@@ -159,8 +168,10 @@ export const InitFlowMixin = {
         e.preventDefault();
         this.tuiModeBtn?.click();
       } else if (e.key === 'c' || e.key === 'C') {
-        e.preventDefault();
-        this.crisisModeBtn?.click();
+        if (this.crisisModeBtn && !this.crisisModeBtn.hidden) {
+          e.preventDefault();
+          this.crisisModeBtn.click();
+        }
       } else if (e.key === 'l' || e.key === 'L') {
         e.preventDefault();
         this.loadGameBtn?.click();
@@ -169,6 +180,21 @@ export const InitFlowMixin = {
         this.helpLandingBtn?.click();
       }
     });
+  },
+
+  /**
+   * Whether experimental modes should be exposed on the landing screen.
+   * Opt in with ?experimental=1 in the URL or localStorage forestExperimental=1.
+   * @private
+   */
+  _isExperimentalEnabled() {
+    try {
+      const params = new URLSearchParams(window.location.search);
+      if (params.get('experimental') === '1' || params.has('dev')) return true;
+      return window.localStorage?.getItem('forestExperimental') === '1';
+    } catch {
+      return false;
+    }
   },
 
   /**

--- a/js/ui/input.js
+++ b/js/ui/input.js
@@ -86,11 +86,17 @@ export const InputMixin = {
       btn.type = 'button';
       btn.className = isModern ? 'decision-card' : 'choice-btn';
 
+      // Keyboard accelerator: 1-9 for the first nine, 0 for a tenth. Beyond ten
+      // options there is no number key, so the badge is dropped rather than
+      // promising a shortcut that does not exist.
+      const shortcutKey = index < 9 ? String(index + 1) : index === 9 ? '0' : null;
+      const prefix = shortcutKey ? `[${shortcutKey}] ` : '';
+
       if (isModern) {
         // Modern card layout with header and checkbox
         btn.innerHTML = `
           <div class="card-header">
-            <span class="card-kbd-badge">KEY [${index + 1}]</span>
+            ${shortcutKey ? `<span class="card-kbd-badge">KEY [${shortcutKey}]</span>` : '<span class="card-kbd-badge card-kbd-badge--none"></span>'}
             <span class="card-checkbox">&#10003;</span>
           </div>
           <div class="card-content">
@@ -104,7 +110,7 @@ export const InputMixin = {
         // Classic terminal style
         const label = document.createElement('span');
         label.className = 'choice-label';
-        label.textContent = `[${index + 1}] ${option.label}`;
+        label.textContent = `${prefix}${option.label}`;
         btn.appendChild(label);
 
         if (option.hint || option.description) {

--- a/js/ui/modernUI.js
+++ b/js/ui/modernUI.js
@@ -41,6 +41,28 @@ export const ModernUIMixin = {
       this.badgeZoneValue.textContent = zoneName.toUpperCase();
     }
 
+    // Stats row (year / funds / eco-health / zone) — live data, not the static
+    // placeholders that used to ship in the markup.
+    if (this.modernYearValue) {
+      this.modernYearValue.textContent = journey.season?.year ? `Year ${journey.season.year}` : `Day ${journey.day}`;
+    }
+    if (this.modernFundsValue) {
+      const budget = Math.round(journey.resources?.budget ?? 0);
+      this.modernFundsValue.textContent = `$${budget.toLocaleString()}`;
+    }
+    if (this.modernZoneValue) {
+      this.modernZoneValue.textContent = journey.area?.becZone || journey.area?.name || journey.zone || '—';
+    }
+    // Eco-health maps to whatever the mode tracks: forest health, then
+    // biodiversity, falling back to a neutral dash when neither applies.
+    const ecoHealth = journey.metrics?.forestHealth ?? journey.values?.biodiversity;
+    if (this.modernEcoValue) {
+      this.modernEcoValue.textContent = Number.isFinite(ecoHealth) ? `${Math.round(ecoHealth)}%` : '—';
+    }
+    if (this.modernEcoFill) {
+      this.modernEcoFill.style.width = `${Number.isFinite(ecoHealth) ? Math.round(ecoHealth) : 0}%`;
+    }
+
     // Metrics sidebar
     if (this.metricProgressValue) {
       this.metricProgressValue.textContent = `${progress}%`;

--- a/src/tui-browser/App.jsx
+++ b/src/tui-browser/App.jsx
@@ -38,9 +38,9 @@ function Header({ onExit, isCrisis }) {
       </div>
       <div className="tui-header-actions">
         <button type="button" className="tui-header-button" onClick={onExit}>
-          Exit
+          ← Main Menu
         </button>
-        <div className="tui-header-help">Press Q to quit</div>
+        <div className="tui-header-help">Press Q to return to the main menu</div>
       </div>
     </header>
   );

--- a/tests/e2e/tui-browser-mobile.spec.js
+++ b/tests/e2e/tui-browser-mobile.spec.js
@@ -84,7 +84,7 @@ test('mobile exit button returns the TUI to the landing page', async ({ page }) 
   await seedBrowser(page, MOBILE_SEED + 1);
   await page.goto('/tui.html');
 
-  await page.getByRole('button', { name: 'Exit' }).click();
+  await page.getByRole('button', { name: '← Main Menu' }).click();
 
   await expect(page).toHaveURL(/\/index\.html$/);
   await expect(page.locator('#new-game-btn')).toBeVisible();


### PR DESCRIPTION
Acts on the "doesn't really work" review. The systems were rich but the
player was asked to decide before the game explained the objective,
blocker, and consequence. This surfaces that context everywhere and tames
the opening turn.

Headers (items 1, 3, 6): every role now boots into a sticky objective
block — Objective, Lane Focus, Next Best Move — plus an always-visible win
gate checklist (planning approval gates, permitting target, silviculture
regen gates, manager survival gates; recon already had its package
checklist). Lane Focus and Current Intel no longer hide behind "Review the
File"/"Review the Briefing".

Onboarding (items 2, 9): random events (and the silviculture contractor
event) are suppressed on day 1 so the first turn teaches the base loop
before any disruption. This also makes the seeded role-smoke boot screens
deterministic, fixing the committed planner/permitter/recce failures.

Choice overload (items 4, 5): the permitting shift menu is split into a
primary set (best move + core pipeline throughput, kept to ~6) and an
"Office & Support" submenu (stakeholders, morale, crisis, recovery),
mirroring recon's pattern. Dropped the duplicate End Day. Number-key
accelerators now cover a tenth option via [0]; beyond ten, no misleading
badge is shown.

Jargon (item 7): professional blockers (registration, CPD gap, paperwork)
carry plain-English translations on the action cards.

Legacy cleanup (item 8): removed the dead _updateCrewConditions,
_getDeskPhase, _miniBar, and _displayCrewStatus methods (and the now-unused
processDailyUpdate import / getDeskActionLaneLabel helper) that still
branched on the retired desk/field journey types.

Landing & accessibility: re-enabled pinch-zoom (dropped maximum-scale /
user-scalable=no); wired the modern stats row to live journey data instead
of hard-coded placeholders; hid experimental Crisis Command behind an
opt-in flag (?experimental=1 / localStorage forestExperimental=1).

Verified: 149 unit tests pass; role-smoke (all 4) and game-modes
planner/permitter/recce/manager playthroughs pass across difficulties.